### PR TITLE
Make `documentType` optional in Order model

### DIFF
--- a/prisma/migrations/20240717030622_add_document_type/migration.sql
+++ b/prisma/migrations/20240717030622_add_document_type/migration.sql
@@ -5,4 +5,4 @@
 
 */
 -- AlterTable
-ALTER TABLE "Order" ADD COLUMN     "documentType" TEXT NOT NULL;
+ALTER TABLE "Order" ADD COLUMN     "documentType" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -143,7 +143,7 @@ model Order {
   cashShift    CashShift   @relation(fields: [cashShiftId], references: [id], onDelete: SetNull, onUpdate: Cascade)
   payments     Payment[]
   documents    Document[]
-  documentType String
+  documentType String?
   createdAt    DateTime    @default(now())
   updatedAt    DateTime    @updatedAt
   orderItems   OrderItem[]
@@ -156,20 +156,20 @@ enum DocumentType {
 }
 
 model Document {
-  id            String       @id @default(uuid())
-  orderId       String
-  customerId    String?
-  total         Decimal
-  documentType  DocumentType
-  series        String
-  number        String
-  dateOfIssue   DateTime
-  qr            String?
-  hash          String?
-  order         Order        @relation(fields: [orderId], references: [id], onDelete: SetNull, onUpdate: Cascade)
-  customer      Customer?     @relation(fields: [customerId], references: [id], onDelete: SetNull, onUpdate: Cascade)
-  createdAt     DateTime     @default(now())
-  updatedAt     DateTime     @updatedAt
+  id           String       @id @default(uuid())
+  orderId      String
+  customerId   String?
+  total        Decimal
+  documentType DocumentType
+  series       String
+  number       String
+  dateOfIssue  DateTime
+  qr           String?
+  hash         String?
+  order        Order        @relation(fields: [orderId], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  customer     Customer?    @relation(fields: [customerId], references: [id], onDelete: SetNull, onUpdate: Cascade)
+  createdAt    DateTime     @default(now())
+  updatedAt    DateTime     @updatedAt
 }
 
 enum CustomerDocumentType {
@@ -193,23 +193,23 @@ model Customer {
 }
 
 model Company {
-  id             String          @id @default(uuid())
-  name           String
-  email          String
-  phone          String
-  address        String
-  ruc            String?
-  customers      Customer[]
-  users          User[]
-  products       Product[]
-  cashShifts     CashShift[]
-  orders         Order[]
-  categories     Category[]
-  stockTransfers StockTransfer[]
-  subdomain      String?         @unique
+  id                 String          @id @default(uuid())
+  name               String
+  email              String
+  phone              String
+  address            String
+  ruc                String?
+  customers          Customer[]
+  users              User[]
+  products           Product[]
+  cashShifts         CashShift[]
+  orders             Order[]
+  categories         Category[]
+  stockTransfers     StockTransfer[]
+  subdomain          String?         @unique
   billingCredentials Json?
-  createdAt      DateTime        @default(now())
-  updatedAt      DateTime        @updatedAt
+  createdAt          DateTime        @default(now())
+  updatedAt          DateTime        @updatedAt
 }
 
 model User {


### PR DESCRIPTION
Updated the `documentType` field in the Order model to be optional (nullable) instead of required. This change also reflects in the schema migration script for consistency.