### PR TITLE
feat: Add ServiceProduct support - Products without inventory management

### DIFF
--- a/prisma/migrations/20260308000000_replace_ispackage_with_product_type/migration.sql
+++ b/prisma/migrations/20260308000000_replace_ispackage_with_product_type/migration.sql
@@ -1,0 +1,24 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `isPackage` on the `Product` table. All the data in the column will be lost.
+
+*/
+-- CreateEnum
+CREATE TYPE "ProductType" AS ENUM ('SINGLE_PRODUCT', 'PACKAGE_PRODUCT', 'SERVICE_PRODUCT');
+
+-- AlterTable: First add the column with a default value
+ALTER TABLE "Product" ADD COLUMN "productType" "ProductType" NOT NULL DEFAULT 'SINGLE_PRODUCT';
+
+-- Update existing data based on isPackage value
+UPDATE "Product" SET "productType" =
+  CASE
+    WHEN "isPackage" = true THEN 'PACKAGE_PRODUCT'::"ProductType"
+    ELSE 'SINGLE_PRODUCT'::"ProductType"
+  END;
+
+-- Now drop the isPackage column
+ALTER TABLE "Product" DROP COLUMN "isPackage";
+
+-- Add index for better query performance
+CREATE INDEX "Product_productType_idx" ON "Product"("productType");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,12 @@ enum UnitType {
   KG
 }
 
+enum ProductType {
+  SINGLE_PRODUCT
+  PACKAGE_PRODUCT
+  SERVICE_PRODUCT
+}
+
 model Product {
   id                         String          @id @default(uuid())
   companyId                  String?
@@ -34,7 +40,7 @@ model Product {
   description                String
   createdAt                  DateTime        @default(now())
   updatedAt                  DateTime        @updatedAt
-  isPackage                  Boolean         @default(false)
+  productType                ProductType     @default(SINGLE_PRODUCT)
   hidden                     Boolean         @default(false)
   photos                     Photo[]
   childPackageItems          PackageItem[]   @relation("ChildProducts")
@@ -42,6 +48,8 @@ model Product {
   stockTransfers             StockTransfer[]
   categories                 Category[]
   orderItems                 OrderItem[]
+
+  @@index([productType])
 }
 
 model PackageItem {

--- a/src/app/[subdomain]/dashboard/(dashboard)/products/page.tsx
+++ b/src/app/[subdomain]/dashboard/(dashboard)/products/page.tsx
@@ -9,6 +9,7 @@ import { getMany, GetManyParams, getTotal } from "@/product/db_repository";
 import { getSession } from "@/lib/auth";
 import ProductModalForm from "@/product/components/form/product-modal-form";
 import AddProductButtons from "@/product/components/add-single-product-button";
+import AddServiceProductButton from "@/product/components/add-service-product-button";
 import SignOutRedirection from "@/shared/components/sign-out-redirection";
 import { ProductsTableFilters } from "@/product/components/data-table/products-table-filters";
 import { ProductsDataTable } from "@/product/components/data-table/products-data-table";
@@ -77,6 +78,7 @@ export default async function Page({ searchParams }: ParamsProps) {
           <div className="flex gap-2 mt-4 md:mt-0">
             <ExportProductsButton />
             <AddProductButtons />
+            <AddServiceProductButton />
           </div>
         </div>
         <Separator/>

--- a/src/new-order/order-form-provider.tsx
+++ b/src/new-order/order-form-provider.tsx
@@ -14,6 +14,7 @@ import {
   Product,
   SingleProductType,
   UNIT_UNIT_TYPE,
+  isSingleProduct,
 } from "@/product/types";
 import { Discount, OrderItem, Payment, PaymentMethod } from "@/order/types";
 import { useToast } from "@/shared/components/ui/use-toast";
@@ -86,7 +87,7 @@ export const useOrderFormActions = (): Actions => {
       }
 
       // TODO: Handle the logic of stock discount on package products
-      if (response.data.type === PackageProductType) return;
+      if (!isSingleProduct(response.data)) return;
 
       if (response.data.stock === 0) {
         toast({

--- a/src/product/actions.ts
+++ b/src/product/actions.ts
@@ -1,10 +1,13 @@
 "use server";
 
-import { find, update, getParentPackages } from "@/product/db_repository";
+import { find, update, getParentPackages, create, findBy } from "@/product/db_repository";
 import { response } from "@/lib/types";
-import { Product } from "@/product/types";
+import { Product, ProductService } from "@/product/types";
 import { revalidatePath } from "next/cache";
 import { getSession } from "@/lib/auth";
+import productCreatorV2 from "@/product/use-cases/product-creator-v2";
+
+const createProduct = productCreatorV2({ create, findBy });
 
 export const hideProduct = async (
   productId: string,
@@ -39,3 +42,38 @@ export const hideProduct = async (
 
   return updateResponse;
 };
+
+export async function createServiceProduct(
+  data: ProductService
+): Promise<response<ProductService>> {
+  try {
+    const session = await getSession();
+
+    if (!session.user) {
+      return {
+        success: false,
+        message: "Usuario no autenticado"
+      };
+    }
+
+    const serviceProduct: ProductService = {
+      ...data,
+      companyId: session.user.companyId
+    };
+
+    const response = await createProduct(serviceProduct);
+
+    if (response.success) {
+      revalidatePath("/dashboard/products");
+      revalidatePath("/api/products");
+    }
+
+    return response as response<ProductService>;
+  } catch (error) {
+    console.error("Error creating service product:", error);
+    return {
+      success: false,
+      message: "Error interno del servidor al crear el servicio"
+    };
+  }
+}

--- a/src/product/components/add-service-product-button.tsx
+++ b/src/product/components/add-service-product-button.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Button } from "@/shared/components/ui/button";
+import { Briefcase } from "lucide-react";
+import { HelpTooltip } from "@/shared/components/ui/help-tooltip";
+import React, { useState } from "react";
+import ServiceProductModal from "@/product/components/form/service-product-modal";
+import { useRouter } from "next/navigation";
+
+export default function AddServiceProductButton() {
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
+
+  const handleClick = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const handleActionPerformed = () => {
+    router.refresh();
+  };
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        className="text-xs md:text-sm ml-2 justify-start"
+        onClick={handleClick}
+      >
+        <Briefcase className="mr-2 h-4 w-4" />
+        <span>Agregar Servicio</span>
+        <HelpTooltip text="Agrega un nuevo servicio sin inventario" />
+      </Button>
+
+      <ServiceProductModal
+        open={open}
+        onClose={handleClose}
+        onActionPerformed={handleActionPerformed}
+      />
+    </>
+  );
+}

--- a/src/product/components/form/service-product-modal.tsx
+++ b/src/product/components/form/service-product-modal.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import { Button } from "@/shared/components/ui/button";
+import { Input, MoneyInput } from "@/shared/components/ui/input";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+} from "@/shared/components/ui/dialog";
+import { ScrollArea } from "@/shared/components/ui/scroll-area";
+import * as z from "zod";
+
+import React, { useEffect, useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { ProductService, ServiceProductType, Photo } from "@/product/types";
+import { createServiceProduct } from "@/product/actions";
+import FileUpload from "@/product/components/file-upload/file-upload";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/shared/components/ui/form";
+import { Heading } from "@/shared/components/ui/heading";
+import { ServiceProductSchema } from "@/product/schema";
+import CategoriesSelector from "@/product/components/category/categories-selector";
+import { useToast } from "@/shared/components/ui/use-toast";
+import { Category } from "@/category/types";
+import { Textarea } from "@/shared/components/ui/textarea";
+import { ReloadIcon } from "@radix-ui/react-icons";
+import { getCompany } from "@/order/actions";
+import CategoriesModal from "@/category/components/category-list-model/category-modal";
+import { HelpTooltip } from "@/shared/components/ui/help-tooltip";
+
+type ServiceProductFormValues = z.infer<typeof ServiceProductSchema>;
+
+const transformToProduct = (data: ServiceProductFormValues): ProductService => {
+  const product: ProductService = {
+    ...data,
+    categories: data.categories || [],
+    type: ServiceProductType,
+    hidden: false,
+  };
+
+  return product;
+};
+
+interface ServiceProductModalProps {
+  open: boolean;
+  onClose: () => void;
+  onActionPerformed: () => void;
+}
+
+export default function ServiceProductModal({
+  open,
+  onClose,
+  onActionPerformed
+}: ServiceProductModalProps) {
+  const [performingAction, setPerformingAction] = useState(false);
+  const { toast } = useToast();
+
+  const form = useForm<ServiceProductFormValues>({
+    resolver: zodResolver(ServiceProductSchema),
+    defaultValues: {
+      companyId: "",
+      name: "",
+      price: 0,
+      description: "",
+      sku: "",
+      categories: [],
+      photos: [],
+    },
+  });
+
+  useEffect(() => {
+    getCompany().then((response) => {
+      if (response.success) {
+        form.setValue("companyId", response.data.id);
+      }
+    });
+  }, [form]);
+
+  const onSubmit = async (data: ServiceProductFormValues) => {
+    setPerformingAction(true);
+    try {
+      const product = transformToProduct(data);
+      const response = await createServiceProduct(product);
+
+      if (response.success) {
+        toast({
+          description: "Servicio creado con éxito",
+        });
+        onActionPerformed();
+        form.reset({
+          companyId: data.companyId,
+          name: "",
+          price: 0,
+          description: "",
+          sku: "",
+          categories: [],
+          photos: [],
+        });
+        onClose();
+      } else {
+        toast({
+          title: "Error",
+          variant: "destructive",
+          description: "Error al registrar el servicio, " + response.message,
+        });
+      }
+    } catch (error) {
+      toast({
+        title: "Error",
+        variant: "destructive",
+        description: "Ocurrió un error al crear el servicio",
+      });
+    } finally {
+      setPerformingAction(false);
+    }
+  };
+
+  const handlePhotosUpdated = async (newPhotos: Photo[]) => {
+    form.setValue("photos", newPhotos);
+  };
+
+  const handleCategoriesUpdated = async (categories: Category[]) => {
+    form.setValue("categories", categories);
+  };
+
+  const addCategoryToProduct = async (category: Category) => {
+    const productCategories = form.getValues("categories") || [];
+    if (productCategories.find((c) => c.id === category.id)) return;
+
+    await handleCategoriesUpdated([...productCategories, category]);
+  };
+
+  const handleDialogChange = (isOpen: boolean) => {
+    if (!isOpen) {
+      form.reset({
+        companyId: form.getValues("companyId"),
+        name: "",
+        price: 0,
+        description: "",
+        sku: "",
+        categories: [],
+        photos: [],
+      });
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleDialogChange}>
+      <DialogContent className="w-full h-full sm:max-w-[750px] sm:h-[750px] flex flex-col justify-center items-center p-0">
+        <ScrollArea className="p-6 w-full">
+          <div className="flex items-center justify-between">
+            <Heading title="Agregar servicio" />
+          </div>
+          <Form {...form}>
+            <form
+              onSubmit={form.handleSubmit(onSubmit)}
+              className="mx-auto space-y-8"
+            >
+              <div className="space-y-4 p-2">
+                <FormField
+                  control={form.control}
+                  name="photos"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormControl>
+                        <FileUpload
+                          onChange={handlePhotosUpdated}
+                          value={field.value || []}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Nombre</FormLabel>
+                      <FormControl>
+                        <Input autoComplete="off" placeholder="Nombre del servicio" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <div className="grid grid-cols-12 gap-4">
+                  <FormField
+                    control={form.control}
+                    name="sku"
+                    render={({ field }) => (
+                      <FormItem className="col-span-6">
+                        <FormLabel>Código de barras</FormLabel>
+                        <FormControl>
+                          <Input
+                            autoComplete="off"
+                            placeholder="Max 13 dígitos"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="price"
+                    render={({ field }) => (
+                      <FormItem className="col-span-6">
+                        <FormLabel>Precio de venta</FormLabel>
+                        <FormControl>
+                          <MoneyInput
+                            autoComplete="off"
+                            type="number"
+                            placeholder="S/ 0.00"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+                <FormField
+                  control={form.control}
+                  name="categories"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Categoría</FormLabel>
+                      <div className="flex justify-between items-center gap-4">
+                        <CategoriesSelector
+                          value={field.value || []}
+                          onChange={handleCategoriesUpdated}
+                        />
+                        <div className="flex items-center gap-2">
+                          <CategoriesModal addCategory={addCategoryToProduct} />
+                          <HelpTooltip text="Categorías del Servicio" />
+                        </div>
+                      </div>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="description"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Descripción</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          rows={4}
+                          placeholder="Escribe la descripción del servicio aquí."
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </form>
+          </Form>
+          <DialogFooter className="sm:justify-start">
+            <DialogClose asChild>
+              <Button type="button" variant="secondary">
+                Cerrar
+              </Button>
+            </DialogClose>
+            <Button
+              className="btn-success"
+              type="button"
+              disabled={performingAction}
+              onClick={form.handleSubmit(onSubmit)}
+            >
+              {performingAction ? (
+                <ReloadIcon className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                "Agregar Servicio"
+              )}
+            </Button>
+          </DialogFooter>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/product/components/form/store.ts
+++ b/src/product/components/form/store.ts
@@ -3,8 +3,10 @@ import {
   type PackageProduct,
   PackageProductType,
   type Product,
+  type ProductService,
   type SingleProduct,
   SingleProductType,
+  ServiceProductType,
 } from "@/product/types";
 
 type ProductFormStateBase = {
@@ -36,16 +38,30 @@ type NewPackageProductFormState = ProductFormStateBase & {
   isNew: true;
 };
 
+type ServiceProductFormState = ProductFormStateBase & {
+  product: ProductService;
+  productType: typeof ServiceProductType;
+  isNew: false;
+};
+
+type NewServiceProductFormState = ProductFormStateBase & {
+  product: null;
+  productType: typeof ServiceProductType;
+  isNew: true;
+};
+
 export type ProductFormState =
   | SingleProductFormState
   | NewSingleProductFormState
   | PackageProductFormState
-  | NewPackageProductFormState;
+  | NewPackageProductFormState
+  | ServiceProductFormState
+  | NewServiceProductFormState;
 
 export type ProductFormActions = {
   setProduct: (product: Product) => void;
   resetProduct: (
-    productType: typeof SingleProductType | typeof PackageProductType,
+    productType: typeof SingleProductType | typeof PackageProductType | typeof ServiceProductType,
   ) => void;
   setOpen: (open: boolean) => void;
   setPerformingAction: (performingAction: boolean) => void;
@@ -68,8 +84,15 @@ export const createProductFormStore = (
     ...initState,
     setProduct: (product) =>
       set(
-        // The following line is a type assertion. We know that the product
         product.type === SingleProductType
+          ? {
+              product,
+              isNew: false,
+              open: true,
+              performingAction: false,
+              productType: product.type,
+            }
+          : product.type === PackageProductType
           ? {
               product,
               isNew: false,

--- a/src/product/db_repository.ts
+++ b/src/product/db_repository.ts
@@ -5,6 +5,8 @@ import {
   PackageProductType,
   Photo,
   Product,
+  ProductService,
+  ServiceProductType,
   ProductSearchParams,
   ProductSortParams,
   SingleProduct,
@@ -50,7 +52,7 @@ const singleProductToPrisma = (
   return {
     ...data,
     sku: product.sku || null,
-    isPackage: false,
+    productType: "SINGLE_PRODUCT",
     price: new Prisma.Decimal(product.price),
     unitType: PRISMA_UNIT_TYPE_MAPPER[product.unitType],
     purchasePrice: product.purchasePrice
@@ -119,8 +121,56 @@ const packageProductToPrisma = (
   return {
     ...data,
     sku,
-    isPackage: true,
+    productType: "PACKAGE_PRODUCT",
   };
+};
+
+const serviceProductToPrisma = (
+  product: ProductService,
+): Prisma.ProductCreateInput => {
+  const { type, photos, categories, ...data } = product;
+
+  return {
+    ...data,
+    sku: product.sku || null,
+    productType: "SERVICE_PRODUCT",
+    price: new Prisma.Decimal(product.price),
+    stock: null,
+    unitType: null,
+    purchasePrice: null,
+  };
+};
+
+const createServiceProduct = async (
+  product: ProductService,
+): Promise<response<ProductService>> => {
+  try {
+    const { photos, categories, ...productData } = product;
+
+    const createdResponse = await prisma().product.create({
+      data: serviceProductToPrisma(product),
+    });
+
+    const productCategories = await prisma().category.findMany({
+      where: { id: { in: categories.map((c) => c.id!) } },
+    });
+
+    const createdProduct: ProductService = {
+      ...createdResponse,
+      companyId: createdResponse.companyId || "some_company_id",
+      type: ServiceProductType,
+      sku: createdResponse.sku || undefined,
+      price: createdResponse.price.toNumber(),
+      categories: productCategories.map((c) => ({
+        ...c,
+        companyId: c.companyId || "some_company_id",
+      })),
+    };
+
+    return { success: true, data: createdProduct };
+  } catch (error: any) {
+    return { success: false, message: error.message };
+  }
 };
 
 const createPackageProduct = async (
@@ -170,9 +220,17 @@ const createPackageProduct = async (
 };
 
 export const create = async (product: Product): Promise<response<Product>> => {
-  const response = await (product.type === SingleProductType
-    ? createSingleProduct(product)
-    : createPackageProduct(product));
+  let response: response<Product>;
+
+  if (product.type === SingleProductType) {
+    response = await createSingleProduct(product);
+  } else if (product.type === PackageProductType) {
+    response = await createPackageProduct(product);
+  } else if (product.type === ServiceProductType) {
+    response = await createServiceProduct(product);
+  } else {
+    return { success: false, message: "Invalid product type" };
+  }
 
   if (!response.success) return response;
 
@@ -207,6 +265,22 @@ const updateSingleProduct = async (
     await prisma().product.update({
       where: { id: product.id },
       data: singleProductToPrisma(product),
+    });
+    return { success: true, data: { ...product } };
+  } catch (error: any) {
+    return { success: false, message: error.message };
+  }
+};
+
+const updateServiceProduct = async (
+  product: ProductService,
+): Promise<response<ProductService>> => {
+  const { photos, categories, type, ...productData } = product;
+
+  try {
+    await prisma().product.update({
+      where: { id: product.id },
+      data: serviceProductToPrisma(product),
     });
     return { success: true, data: { ...product } };
   } catch (error: any) {
@@ -259,15 +333,33 @@ const updatePackageProduct = async (
 };
 
 export const update = async (product: Product): Promise<response<Product>> => {
-  return product.type === SingleProductType
-    ? updateSingleProduct(product)
-    : updatePackageProduct(product);
+  if (product.type === SingleProductType) {
+    return updateSingleProduct(product);
+  } else if (product.type === PackageProductType) {
+    return updatePackageProduct(product);
+  } else if (product.type === ServiceProductType) {
+    return updateServiceProduct(product);
+  } else {
+    return { success: false, message: "Invalid product type" };
+  }
 };
 
 const prismaToProduct = async (
   prismaProduct: PrismaProduct & { categories: PrismaCategory[] },
 ): Promise<Product> => {
-  if (prismaProduct.isPackage) {
+  if (prismaProduct.productType === "SERVICE_PRODUCT") {
+    return {
+      ...prismaProduct,
+      companyId: prismaProduct.companyId || "some_company_id",
+      type: ServiceProductType,
+      sku: prismaProduct.sku || undefined,
+      price: prismaProduct.price.toNumber(),
+      categories: prismaProduct.categories.map((c) => ({
+        ...c,
+        companyId: c.companyId || "some_company_id",
+      })),
+    };
+  } else if (prismaProduct.productType === "PACKAGE_PRODUCT") {
     const productItems = await prisma().packageItem.findMany({
       where: { parentProductId: prismaProduct.id },
       include: { parentProduct: true },
@@ -359,7 +451,7 @@ export const getMany = async ({
     if (productType)
       query.where = {
         ...query.where,
-        isPackage: productType === PackageProductType,
+        productType: productType === PackageProductType ? "PACKAGE_PRODUCT" : "SINGLE_PRODUCT",
       };
 
     if (categoryId)
@@ -527,7 +619,7 @@ export const search = async ({
   try {
     const query: Prisma.ProductWhereInput = {
       name: { contains: q, mode: "insensitive" },
-      isPackage: false,
+      productType: "SINGLE_PRODUCT",
     };
     if (categoryId) query.categories = { some: { id: categoryId } };
 

--- a/src/product/schema.ts
+++ b/src/product/schema.ts
@@ -77,3 +77,26 @@ export const PackageProductSchema = z.object({
   updatedAt: z.date().optional(),
   createdAt: z.date().optional(),
 });
+
+export const ServiceProductSchema = z.object({
+  id: z.string().optional(),
+  companyId: z.string(),
+  name: z.string().min(3, {
+    message: "El nombre del servicio debe tener al menos 3 caracteres",
+  }),
+  price: z.coerce.number().gt(0, "El servicio debe tener un precio"),
+  description: z.string(),
+  sku: z
+    .string()
+    .regex(/^[a-zA-Z0-9_]*$/, {
+      message: "SKU solo puede contener carácteres alfanuméricos y guión abajo",
+    })
+    .optional(),
+  photos: z
+    .array(PhotoSchema)
+    .max(IMG_MAX_LIMIT, { message: "You can only add up to 5 images" })
+    .optional(),
+  categories: z.array(CategorySchema),
+  updatedAt: z.date().optional(),
+  createdAt: z.date().optional(),
+});

--- a/src/product/types.ts
+++ b/src/product/types.ts
@@ -46,11 +46,23 @@ export type PackageProduct = ProductBase & {
   productItems: ProductItem[];
 };
 
-export type Product = SingleProduct | PackageProduct;
+export const ServiceProductType = "ServiceProduct";
+export type TypeServiceProductType = typeof ServiceProductType;
+
+export type ProductService = ProductBase & {
+  type: typeof ServiceProductType;
+};
+
+// Union type for products that have stock
+export type StockableProduct = SingleProduct | PackageProduct;
+
+// Union type for all products
+export type Product = StockableProduct | ProductService;
 
 type ProductTypeMap = {
   [SingleProductType]: SingleProduct;
   [PackageProductType]: PackageProduct;
+  [ServiceProductType]: ProductService;
 };
 
 export type ProductType = keyof ProductTypeMap;
@@ -62,6 +74,32 @@ export type ProductItem = {
   productId: string;
   productName: string;
   quantity: number;
+};
+
+// Type guard functions
+export const isStockableProduct = (
+  product: Product
+): product is StockableProduct => {
+  return product.type === SingleProductType ||
+         product.type === PackageProductType;
+};
+
+export const isServiceProduct = (
+  product: Product
+): product is ProductService => {
+  return product.type === ServiceProductType;
+};
+
+export const isSingleProduct = (
+  product: Product
+): product is SingleProduct => {
+  return product.type === SingleProductType;
+};
+
+export const isPackageProduct = (
+  product: Product
+): product is PackageProduct => {
+  return product.type === PackageProductType;
 };
 
 export type ProductSearchParams = {

--- a/src/product/use-cases/product-creator-v2.ts
+++ b/src/product/use-cases/product-creator-v2.ts
@@ -1,0 +1,108 @@
+import {
+  Product,
+  ProductSearchParams,
+  SingleProductType,
+  PackageProductType,
+  ServiceProductType,
+} from "@/product/types";
+import {
+  PackageProductSchema,
+  SingleProductSchema,
+  ServiceProductSchema
+} from "@/product/schema";
+import { response } from "@/lib/types";
+
+interface Repository {
+  create: (product: Product) => Promise<response<Product>>;
+  findBy: (params: ProductSearchParams) => Promise<response<Product>>;
+}
+
+// Pure function to validate product based on type
+const validateProduct = (product: Product): response<Product> => {
+  let parsedProduct;
+
+  switch (product.type) {
+    case SingleProductType:
+      parsedProduct = SingleProductSchema.safeParse(product);
+      break;
+    case PackageProductType:
+      parsedProduct = PackageProductSchema.safeParse(product);
+      break;
+    case ServiceProductType:
+      parsedProduct = ServiceProductSchema.safeParse(product);
+      break;
+    default:
+      return { success: false, message: "Tipo de producto no válido" };
+  }
+
+  if (!parsedProduct.success) {
+    return { success: false, message: parsedProduct.error.message };
+  }
+
+  return { success: true, data: product };
+};
+
+// Pure function to check if SKU validation is needed
+const needsSkuValidation = (product: Product): boolean => {
+  return Boolean(product.sku && product.sku.length > 0);
+};
+
+// Async function to validate SKU uniqueness
+const validateSkuUniqueness = (repository: Repository) =>
+  async (product: Product): Promise<response<Product>> => {
+    if (!needsSkuValidation(product)) {
+      return { success: true, data: product };
+    }
+
+    const { success: productFound } = await repository.findBy({
+      sku: product.sku,
+      companyId: product.companyId,
+    });
+
+    if (productFound) {
+      return { success: false, message: "Ya existe un producto con el sku" };
+    }
+
+    return { success: true, data: product };
+  };
+
+// Function composition utility for response types
+const pipeResponse = <T>(
+  ...fns: Array<(arg: T) => response<T> | Promise<response<T>>>
+) =>
+  async (value: T): Promise<response<T>> => {
+    let result: response<T> = { success: true, data: value };
+
+    for (const fn of fns) {
+      if (!result.success) break;
+
+      const fnResult = await fn(result.data);
+      if (!fnResult.success) {
+        return fnResult;
+      }
+      result = fnResult;
+    }
+
+    return result;
+  };
+
+// Main product creator function using composition
+export default function productCreatorV2(repository: Repository) {
+  return async (product: Product): Promise<response<Product>> => {
+    // Compose validation pipeline
+    const validatePipeline = pipeResponse(
+      validateProduct,
+      validateSkuUniqueness(repository)
+    );
+
+    // Execute validation pipeline
+    const validationResult = await validatePipeline(product);
+
+    if (!validationResult.success) {
+      return validationResult;
+    }
+
+    // Create the product
+    return repository.create(validationResult.data);
+  };
+}

--- a/src/product/use-cases/product-creator.ts
+++ b/src/product/use-cases/product-creator.ts
@@ -1,10 +1,15 @@
 import {
   Product,
   ProductSearchParams,
-  SingleProduct,
   SingleProductType,
+  PackageProductType,
+  ServiceProductType,
 } from "@/product/types";
-import { PackageProductSchema, SingleProductSchema } from "@/product/schema";
+import {
+  PackageProductSchema,
+  SingleProductSchema,
+  ServiceProductSchema,
+} from "@/product/schema";
 import { response } from "@/lib/types";
 
 interface Repository {
@@ -16,10 +21,21 @@ export default async function productCreator(
   repository: Repository,
   product: Product,
 ): Promise<response<Product>> {
-  const parsedProduct =
-    product.type === SingleProductType
-      ? SingleProductSchema.safeParse(product)
-      : PackageProductSchema.safeParse(product);
+  let parsedProduct;
+
+  switch (product.type) {
+    case SingleProductType:
+      parsedProduct = SingleProductSchema.safeParse(product);
+      break;
+    case PackageProductType:
+      parsedProduct = PackageProductSchema.safeParse(product);
+      break;
+    case ServiceProductType:
+      parsedProduct = ServiceProductSchema.safeParse(product);
+      break;
+    default:
+      return { success: false, message: "Tipo de producto no válido" };
+  }
 
   if (!parsedProduct.success) {
     return { success: false, message: parsedProduct.error.message };

--- a/src/stock-transfer/use-cases/generate-order-stock-transfer.ts
+++ b/src/stock-transfer/use-cases/generate-order-stock-transfer.ts
@@ -4,8 +4,9 @@ import {
 } from "@/stock-transfer/types";
 import { Order, OrderItem } from "@/order/types";
 import {
+  isPackageProduct,
+  isStockableProduct,
   PackageProduct,
-  PackageProductType,
   Product,
   SingleProduct,
 } from "@/product/types";
@@ -59,9 +60,14 @@ const generateOrderItemStockTransfer = async (
   }
 
   const product = productFoundResponse.data;
+
+  if (!isStockableProduct(product)) {
+    return { success: true, data: [] }
+  }
+
   let stockTransfers: OrderStockTransfer[];
 
-  if (product.type == PackageProductType) {
+  if (isPackageProduct(product)) {
     stockTransfers = generatePackageProductStockTransfers(
       orderItem,
       userId,


### PR DESCRIPTION
## Summary

- **Replace `isPackage` boolean with `productType` enum** (`SINGLE_PRODUCT`, `PACKAGE_PRODUCT`, `SERVICE_PRODUCT`) enabling a three-type product system
- **Add ServiceProduct type** for products that don't require inventory tracking (services like consultations, maintenance, repairs, etc.)
- **Add type guards** (`isStockableProduct`, `isServiceProduct`, `isSingleProduct`, `isPackageProduct`) for compile-time type safety
- **Add UI components** for service product creation (button + modal) in the products page
- **Update stock transfer logic** to skip service products (no inventory operations)
- **Include database migration** that safely transforms existing data while maintaining backward compatibility

## Test plan

- [ ] Verify existing Single and Package products continue to work after migration
- [ ] Create a new ServiceProduct through the "Agregar Servicio" button
- [ ] Verify service products don't show stock/unitType/purchasePrice fields
- [ ] Verify service products appear in the products list
- [ ] Verify ordering a service product doesn't trigger stock transfers
- [ ] Verify SKU uniqueness validation works for service products

🤖 Generated with [Claude Code](https://claude.com/claude-code)