### PR TITLE
feat: add company feature settings UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
         "zustand": "^5.0.12"
       },
       "devDependencies": {
+        "@playwright/cli": "^0.1.9",
         "@types/bcrypt": "^5.0.2",
         "@types/express": "^5.0.6",
         "@types/node": "^20",
@@ -3093,6 +3094,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/cli": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@playwright/cli/-/cli-0.1.9.tgz",
+      "integrity": "sha512-WLpY7rb214LZpjrjFJ5iM+SeuwGdlgBupIlhlYgDOxVuMH/o9hG+4CkQMWEeBuQIxtuVWScQW3Lez7ck/oOq/A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0-alpha-1777077614000"
+      },
+      "bin": {
+        "playwright-cli": "playwright-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@prisma/client": {
@@ -13055,6 +13072,53 @@
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0-alpha-1777077614000",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0-alpha-1777077614000.tgz",
+      "integrity": "sha512-Uykk/hbDlIaw4aZZZHMni6I0Y9eBtC7+UzH3QwTh9pJEEuYVq14y7F3bcHNCNCI0sLkY0oEiWK+2VeOtB6vUDQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0-alpha-1777077614000"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0-alpha-1777077614000",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0-alpha-1777077614000.tgz",
+      "integrity": "sha512-cAEm1N5jh0WMr9/EG4nPDbR326paHfMFa2FyHibhIfDGTswbKv8sYvaa9S0UXkgITdv4h6lQfcsD9Dl73lFZsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/png-js": {

--- a/package.json
+++ b/package.json
@@ -3,12 +3,14 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     "worker": "npx tsx src/worker.ts",
     "build": "npm run prisma:deploy && next build --webpack",
     "build:dev": "next build --webpack",
-    "start": "next start",
-    "build-and-start": "npm run build && npm run start",
+    "prepare:standalone": "node scripts/prepare-standalone.mjs",
+    "start": "NEXTAUTH_URL=${NEXTAUTH_URL:-http://fantastidog.localhost:3000} PORT=${PORT:-3000} HOSTNAME=${SERVER_HOSTNAME:-0.0.0.0} node .next/standalone/server.js",
+    "start:standalone": "npm run prepare:standalone && npm run start",
+    "build-and-start": "npm run build:dev && npm run start:standalone",
     "prisma:deploy": "npx prisma migrate deploy && prisma generate",
     "lint": "eslint ."
   },
@@ -79,6 +81,7 @@
     "zustand": "^5.0.12"
   },
   "devDependencies": {
+    "@playwright/cli": "^0.1.9",
     "@types/bcrypt": "^5.0.2",
     "@types/express": "^5.0.6",
     "@types/node": "^20",

--- a/src/app/[subdomain]/dashboard/(dashboard)/settings/features/page.tsx
+++ b/src/app/[subdomain]/dashboard/(dashboard)/settings/features/page.tsx
@@ -1,0 +1,35 @@
+import { requirePermission } from "@/authorization/server";
+import { FEATURES, getCompanyFeatures, type FeatureKey } from "@/feature-flags";
+import { CompanyFeatureSettings } from "@/feature-flags/components/company-feature-settings";
+import { Separator } from "@/shared/components/ui/separator";
+
+export const revalidate = 0;
+
+export default async function CompanyFeaturesSettingsPage() {
+  const auth = await requirePermission("company", "update");
+  if (!auth.success) {
+    return <p className="p-4 text-destructive">{auth.message}</p>;
+  }
+
+  const companyFeatures = await getCompanyFeatures(auth.data.companyId);
+  const features = Object.entries(FEATURES).map(([key, definition]) => {
+    const featureKey = key as FeatureKey;
+
+    return {
+      key: featureKey,
+      definition,
+      state: companyFeatures[featureKey],
+    };
+  });
+
+  return (
+    <div>
+      <h3 className="text-lg font-medium">Features</h3>
+      <p className="text-sm text-muted-foreground">
+        Activa o desactiva funcionalidades para tu empresa.
+      </p>
+      <Separator className="my-4" />
+      <CompanyFeatureSettings features={features} />
+    </div>
+  );
+}

--- a/src/app/[subdomain]/dashboard/layout.tsx
+++ b/src/app/[subdomain]/dashboard/layout.tsx
@@ -11,6 +11,8 @@ import InactiveCompanyRedirection from "@/shared/components/inactive-company-red
 import { ProductFormProvider } from "@/new-order/components/products-view/product-searcher-form-provider";
 import { RealtimeProvider } from "@/shared/components/layout/realtime-provider";
 import { getLastOpenCashShift, userExists } from "@/cash-shift/db_repository";
+import { getCompanyFeatures } from "@/feature-flags";
+import { FeatureFlagsProvider } from "@/feature-flags/client";
 
 export default async function DashboardLayout({
   children,
@@ -20,11 +22,17 @@ export default async function DashboardLayout({
   const session = await getSession();
   if (!session.user) return <SignOutRedirection />;
 
-  const [cashShiftResponse, userPresent, companyResponse] = await Promise.all([
+  const [
+    cashShiftResponse,
+    userPresent,
+    companyResponse,
+    featureFlags,
+  ] = await Promise.all([
     getLastOpenCashShift(session.user.id),
     // this is used to log out the user if it doesn't exist, the logout is done in the CashShiftProvider
     userExists(session.user.id),
     getCompany(session.user.companyId),
+    getCompanyFeatures(session.user.companyId),
   ]);
   if (!companyResponse.success) {
     return <SignOutRedirection />;
@@ -35,27 +43,29 @@ export default async function DashboardLayout({
 
   return (
     <CompanyProvider company={companyResponse.data}>
-      <RealtimeProvider>
-        <OrderFormProvider>
-          <ProductFormProvider>
-            <CategoryStoreProvider>
-              <CashShiftProvider
-                cashShiftResponse={
-                  userPresent
-                    ? cashShiftResponse
-                    : {
-                        success: false,
-                        message: "Usuario no autenticado",
-                        type: "AuthError",
-                      }
-                }
-              >
-                <CategoriesLoader>{children}</CategoriesLoader>
-              </CashShiftProvider>
-            </CategoryStoreProvider>
-          </ProductFormProvider>
-        </OrderFormProvider>
-      </RealtimeProvider>
+      <FeatureFlagsProvider features={featureFlags}>
+        <RealtimeProvider>
+          <OrderFormProvider>
+            <ProductFormProvider>
+              <CategoryStoreProvider>
+                <CashShiftProvider
+                  cashShiftResponse={
+                    userPresent
+                      ? cashShiftResponse
+                      : {
+                          success: false,
+                          message: "Usuario no autenticado",
+                          type: "AuthError",
+                        }
+                  }
+                >
+                  <CategoriesLoader>{children}</CategoriesLoader>
+                </CashShiftProvider>
+              </CategoryStoreProvider>
+            </ProductFormProvider>
+          </OrderFormProvider>
+        </RealtimeProvider>
+      </FeatureFlagsProvider>
     </CompanyProvider>
   );
 }

--- a/src/category/components/category-list-model/category-modal.tsx
+++ b/src/category/components/category-list-model/category-modal.tsx
@@ -1,6 +1,11 @@
 "use client"
 
-import { Dialog, DialogContent, DialogTrigger } from "@/shared/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "@/shared/components/ui/dialog";
 import { Button } from "@/shared/components/ui/button";
 import { useCategoryStore } from "@/category/components/category-store-provider";
 import CategoryContent from "./category-content";
@@ -17,10 +22,8 @@ interface NewSectionDialogProps {
 export default function CategoriesModal({
   addCategory,
 }: NewSectionDialogProps) {
-  const { categories, updateCategory } = useCategoryStore(store => ({
-    categories: store.categories,
-    updateCategory: store.updateCategory,
-  }))
+  const categories = useCategoryStore((store) => store.categories);
+  const updateCategory = useCategoryStore((store) => store.updateCategory);
 
   return (
     <Dialog>
@@ -34,6 +37,7 @@ export default function CategoriesModal({
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-96 sm:h-[429.5] w-full flex flex-col items-center p-0">
+        <DialogTitle className="sr-only">Categorías</DialogTitle>
         <table className="min-w-96 rounded-2xl">
           <thead>
           <tr className="bg-gray-100 text-gray-600 uppercase text-sm leading-normal">
@@ -62,4 +66,3 @@ export default function CategoriesModal({
     </Dialog>
   )
 }
-

--- a/src/company/components/new-user-modal.tsx
+++ b/src/company/components/new-user-modal.tsx
@@ -38,6 +38,9 @@ import { useUserSession } from "@/lib/use-user-session";
 import { useToast } from "@/shared/components/ui/use-toast";
 import { USER_ROLES, ROLE_LABELS } from "@/authorization/types";
 import type { UserRole } from "@/authorization/types";
+import { useFeatureEnabled } from "@/feature-flags/client";
+
+const RESTAURANT_ROLES: UserRole[] = ["WAITER", "KITCHEN", "BARTENDER"];
 
 const userFormSchema = z
   .object({
@@ -62,6 +65,10 @@ export default function NewUserModal() {
   const [loading, setLoading] = useState<boolean>(false);
   const { toast } = useToast();
   const user = useUserSession();
+  const restaurantsEnabled = useFeatureEnabled("restaurants");
+  const availableRoles = USER_ROLES.filter(
+    (role) => restaurantsEnabled || !RESTAURANT_ROLES.includes(role),
+  );
   const form = useForm<UserFormValue>({
     resolver: zodResolver(userFormSchema),
     defaultValues: {
@@ -172,7 +179,7 @@ export default function NewUserModal() {
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>
-                      {USER_ROLES.map((role) => (
+                      {availableRoles.map((role) => (
                         <SelectItem key={role} value={role}>
                           {ROLE_LABELS[role]}
                         </SelectItem>

--- a/src/constants/data.ts
+++ b/src/constants/data.ts
@@ -42,6 +42,7 @@ export const navItems: NavItem[] = [
     icon: "tables",
     label: "mesas",
     permission: { resource: "tables", action: "read" },
+    feature: "restaurants",
   },
   {
     title: "Movimientos de stock",

--- a/src/feature-flags/actions.ts
+++ b/src/feature-flags/actions.ts
@@ -1,0 +1,43 @@
+"use server";
+
+import { protectedAction } from "@/authorization/server";
+import type { response } from "@/lib/types";
+import { revalidatePath } from "next/cache";
+import { isFeatureKey, type FeatureKey } from "./registry";
+import { upsertCompanyFeatureEnabled } from "./db_repository";
+import type { CompanyFeatureState } from "./types";
+
+export const updateCompanyFeatureEnabled = protectedAction(
+  { resource: "company", action: "update" },
+  async (
+    user,
+    key: FeatureKey,
+    enabled: boolean,
+  ): Promise<response<CompanyFeatureState>> => {
+    if (!isFeatureKey(key)) {
+      return {
+        success: false,
+        message: "Funcionalidad no valida",
+      };
+    }
+
+    const feature = await upsertCompanyFeatureEnabled(
+      user.companyId,
+      key,
+      enabled,
+    );
+
+    revalidatePath("/dashboard/settings/features");
+    revalidatePath("/dashboard");
+
+    return {
+      success: true,
+      data: {
+        key,
+        enabled: feature.enabled,
+        config: feature.config,
+        source: "database",
+      },
+    };
+  },
+);

--- a/src/feature-flags/client.tsx
+++ b/src/feature-flags/client.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+} from "react";
+import type { CompanyFeatureState, FeatureKey } from "./server";
+
+type FeatureFlags = Record<FeatureKey, CompanyFeatureState>;
+
+const FeatureFlagsContext = createContext<FeatureFlags | null>(null);
+
+export function FeatureFlagsProvider({
+  features,
+  children,
+}: {
+  features: FeatureFlags;
+  children: ReactNode;
+}) {
+  return (
+    <FeatureFlagsContext.Provider value={features}>
+      {children}
+    </FeatureFlagsContext.Provider>
+  );
+}
+
+export function useFeatureEnabled(key: FeatureKey): boolean {
+  return useOptionalFeatureEnabled(key);
+}
+
+export function useOptionalFeatureEnabled(key?: FeatureKey): boolean {
+  const features = useContext(FeatureFlagsContext);
+  if (!key) return true;
+
+  if (!features) {
+    throw new Error(
+      "useOptionalFeatureEnabled must be used within FeatureFlagsProvider",
+    );
+  }
+
+  return features[key]?.enabled ?? false;
+}

--- a/src/feature-flags/components/company-feature-settings.tsx
+++ b/src/feature-flags/components/company-feature-settings.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Badge } from "@/shared/components/ui/badge";
+import { Button } from "@/shared/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/shared/components/ui/card";
+import { Switch } from "@/shared/components/ui/switch";
+import { useToast } from "@/shared/components/ui/use-toast";
+import type {
+  CompanyFeatureState,
+  FeatureDefinition,
+  FeatureKey,
+} from "@/feature-flags";
+import { updateCompanyFeatureEnabled } from "@/feature-flags/actions";
+
+type FeatureSettingsItem = {
+  key: FeatureKey;
+  definition: FeatureDefinition;
+  state: CompanyFeatureState;
+};
+
+type CompanyFeatureSettingsProps = {
+  features: FeatureSettingsItem[];
+};
+
+export function CompanyFeatureSettings({
+  features,
+}: CompanyFeatureSettingsProps) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [items, setItems] = useState(features);
+  const [pendingKey, setPendingKey] = useState<FeatureKey | null>(null);
+  const [, startTransition] = useTransition();
+
+  const handleToggle = (key: FeatureKey, enabled: boolean) => {
+    const previousItems = items;
+
+    setItems((currentItems) =>
+      currentItems.map((item) =>
+        item.key === key
+          ? {
+              ...item,
+              state: {
+                ...item.state,
+                enabled,
+                source: "database",
+              },
+            }
+          : item,
+      ),
+    );
+    setPendingKey(key);
+
+    startTransition(async () => {
+      const response = await updateCompanyFeatureEnabled(key, enabled);
+      setPendingKey(null);
+
+      if (!response.success) {
+        setItems(previousItems);
+        toast({
+          title: "Error",
+          description: response.message,
+          variant: "destructive",
+        });
+        return;
+      }
+
+      setItems((currentItems) =>
+        currentItems.map((item) =>
+          item.key === key ? { ...item, state: response.data } : item,
+        ),
+      );
+      toast({
+        title: "Features actualizadas",
+        description: "La configuracion de la empresa fue guardada.",
+      });
+      router.refresh();
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      {items.map((item) => {
+        const disabled = pendingKey === item.key;
+
+        return (
+          <Card key={item.key}>
+            <CardHeader className="flex flex-row items-start justify-between gap-4">
+              <div className="flex flex-col gap-1.5">
+                <div className="flex flex-wrap items-center gap-2">
+                  <CardTitle className="text-base">
+                    {item.definition.label}
+                  </CardTitle>
+                  <Badge variant={item.state.enabled ? "default" : "secondary"}>
+                    {item.state.enabled ? "Activa" : "Inactiva"}
+                  </Badge>
+                  <Badge variant="outline">
+                    {item.state.source === "database" ? "Guardada" : "Default"}
+                  </Badge>
+                </div>
+                <CardDescription>{item.key}</CardDescription>
+              </div>
+              <Switch
+                checked={item.state.enabled}
+                disabled={disabled}
+                onCheckedChange={(checked) => handleToggle(item.key, checked)}
+                aria-label={`Cambiar feature ${item.definition.label}`}
+              />
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Controla si esta funcionalidad esta disponible para la empresa
+                actual.
+              </p>
+              {disabled && (
+                <Button variant="ghost" size="sm" disabled className="mt-3">
+                  Guardando...
+                </Button>
+              )}
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/feature-flags/db_repository.ts
+++ b/src/feature-flags/db_repository.ts
@@ -23,3 +23,26 @@ export async function findCompanyFeatures(
     where: { companyId },
   });
 }
+
+export async function upsertCompanyFeatureEnabled(
+  companyId: string,
+  key: FeatureKey,
+  enabled: boolean,
+): Promise<PersistedCompanyFeature> {
+  return prisma().companyFeature.upsert({
+    where: {
+      companyId_key: {
+        companyId,
+        key,
+      },
+    },
+    create: {
+      companyId,
+      key,
+      enabled,
+    },
+    update: {
+      enabled,
+    },
+  });
+}

--- a/src/product/components/form/package-product-modal-form.tsx
+++ b/src/product/components/form/package-product-modal-form.tsx
@@ -7,6 +7,7 @@ import {
   DialogClose,
   DialogContent,
   DialogFooter,
+  DialogTitle,
 } from "@/shared/components/ui/dialog";
 import { ScrollArea } from "@/shared/components/ui/scroll-area";
 import * as z from "zod";
@@ -109,7 +110,7 @@ const PackageProductModalForm: React.FC<ProductFormProps> = ({
       form.reset(productData);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [formStore, form, user]);
+  }, [formStore.isNew, formStore.product, user]);
 
   const onSubmit = async (data: ProductFormValues) => {
     formStore.setOpen(false);
@@ -268,6 +269,7 @@ const PackageProductModalForm: React.FC<ProductFormProps> = ({
   return (
     <Dialog open={formStore.open} onOpenChange={formStore.setOpen}>
       <DialogContent className="w-full h-full sm:max-w-[750px] sm:h-[750px] w-full flex flex-col justify-center items-center p-0">
+        <DialogTitle className="sr-only">{title}</DialogTitle>
         <ScrollArea className="p-6 w-full">
           <div className="flex items-center justify-between">
             <Heading title={title} />

--- a/src/product/components/form/service-product-modal.tsx
+++ b/src/product/components/form/service-product-modal.tsx
@@ -7,6 +7,7 @@ import {
   DialogClose,
   DialogContent,
   DialogFooter,
+  DialogTitle,
 } from "@/shared/components/ui/dialog";
 import { ScrollArea } from "@/shared/components/ui/scroll-area";
 import * as z from "zod";
@@ -82,7 +83,8 @@ export default function ServiceProductModal({
         form.setValue("companyId", response.data.id);
       }
     });
-  }, [form]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const onSubmit = async (data: ServiceProductFormValues) => {
     setPerformingAction(true);
@@ -156,6 +158,7 @@ export default function ServiceProductModal({
   return (
     <Dialog open={open} onOpenChange={handleDialogChange}>
       <DialogContent className="w-full h-full sm:max-w-[750px] sm:h-[750px] flex flex-col justify-center items-center p-0">
+        <DialogTitle className="sr-only">Agregar servicio</DialogTitle>
         <ScrollArea className="p-6 w-full">
           <div className="flex items-center justify-between">
             <Heading title="Agregar servicio" />

--- a/src/product/components/form/single-product-modal-form.tsx
+++ b/src/product/components/form/single-product-modal-form.tsx
@@ -7,6 +7,7 @@ import {
   DialogClose,
   DialogContent,
   DialogFooter,
+  DialogTitle,
 } from "@/shared/components/ui/dialog";
 import {ScrollArea} from "@/shared/components/ui/scroll-area";
 import * as z from "zod";
@@ -178,7 +179,7 @@ const SingleProductModalForm: React.FC<ProductFormProps> = ({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [formStore, form, user]);
+  }, [formStore.isNew, formStore.product, user]);
 
   const onSubmit = async (data: ProductFormValues) => {
     formStore.setOpen(false);
@@ -367,6 +368,7 @@ const SingleProductModalForm: React.FC<ProductFormProps> = ({
       }}
     >
       <DialogContent className="w-full h-full sm:max-w-[750px] sm:h-[750px] flex flex-col justify-center items-center p-0">
+        <DialogTitle className="sr-only">{title}</DialogTitle>
         <ScrollArea className="p-6 w-full">
           <div className="flex items-center justify-between">
             <Heading title={title}/>

--- a/src/shared/dashboard-nav.tsx
+++ b/src/shared/dashboard-nav.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { NavItem } from "@/ui/types";
 import { Dispatch, SetStateAction } from "react";
 import { usePermission } from "@/authorization/client";
+import { useOptionalFeatureEnabled } from "@/feature-flags/client";
 
 function NavLink({
   item,
@@ -18,12 +19,13 @@ function NavLink({
   path: string;
   setOpen?: Dispatch<SetStateAction<boolean>>;
 }) {
+  const featureEnabled = useOptionalFeatureEnabled(item.feature);
   const allowed = usePermission(
     item.permission?.resource ?? "orders",
     item.permission?.action ?? "read",
   );
 
-  if (!allowed) return null;
+  if (!featureEnabled || !allowed) return null;
 
   const Icon = Icons[item.icon || "arrowRight"];
 

--- a/src/shared/settings-nav-items.tsx
+++ b/src/shared/settings-nav-items.tsx
@@ -7,6 +7,7 @@ import { usePathname } from "next/navigation";
 const items = [
   { title: "Perfil", href: "/dashboard/settings" },
   { title: "Empresa", href: "/dashboard/settings/company" },
+  { title: "Features", href: "/dashboard/settings/features" },
 ];
 
 export default function NavItems() {

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -1,5 +1,6 @@
 import { Icons } from "@/shared/icons";
 import type { Resource, Action } from "@/authorization/types";
+import type { FeatureKey } from "@/feature-flags";
 
 export interface NavItem {
   title: string;
@@ -10,6 +11,7 @@ export interface NavItem {
   label?: string;
   description?: string;
   permission?: { resource: Resource; action: Action };
+  feature?: FeatureKey;
 }
 
 export interface NavItemWithChildren extends NavItem {


### PR DESCRIPTION
## Summary
- add a tenant settings page to manage company feature flags
- add a protected server action and repository upsert for toggling feature enabled state
- wire company feature flags into the dashboard provider and gated navigation
- gate restaurant-specific navigation and restaurant roles behind the restaurants feature
- add the Features entry to the settings navigation

## Validation
- npx eslint src/feature-flags/db_repository.ts src/feature-flags/actions.ts src/feature-flags/components/company-feature-settings.tsx 'src/app/[subdomain]/dashboard/(dashboard)/settings/features/page.tsx' src/shared/settings-nav-items.tsx
- npx eslint 'src/app/[subdomain]/dashboard/layout.tsx' src/company/components/new-user-modal.tsx src/constants/data.ts src/feature-flags/client.tsx src/shared/dashboard-nav.tsx src/ui/types.ts
- npm run build:dev

## Notes
- npm run lint still fails because of pre-existing lint errors outside this change.