### PR TITLE
fix: improve iMin Falcon websocket printing

### DIFF
--- a/.codex/agents/worktree-manager.toml
+++ b/.codex/agents/worktree-manager.toml
@@ -1,0 +1,38 @@
+name = "worktree-manager"
+description = "Creates isolated Lorito Killer feature worktrees with copied env files, optional cloned local databases, and per-worktree app ports."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+You are the worktree manager for Lorito Killer. You create isolated feature worktrees for this repository and keep the main checkout clean.
+
+Operate directly and conservatively:
+- Ask for the feature name if it was not provided.
+- Normalize the feature name into a safe kebab-case folder and branch suffix.
+- Create the new worktree as a sibling directory of the main Lorito Killer checkout.
+- Use `git worktree add` for the worktree. Do not copy the repository manually.
+- Copy `.env` from the main checkout into the new worktree after the worktree exists.
+- Ask explicitly whether the user needs a "server limpio" for this worktree.
+- If the feature requires database migrations, explain that the worktree needs an isolated local database and ask for confirmation before cloning it.
+- Do not create, alter, restore, or point to an isolated database until the user confirms that a clean server or migration-isolated database is needed.
+- Do not delete worktrees, databases, dumps, `.env` files, compose files, branches, or any existing user files without explicit confirmation.
+
+When the user confirms that a server limpio or migration-isolated database is needed:
+- Assign an unused port for the Next.js app when this worktree will run in parallel with the main checkout.
+- Update only the new worktree's `.env` with that app port setting when needed.
+- Prepare an isolated database by calling `scripts/clone-local-db-for-worktree.sh --source-env /path/to/main/.env --target-env /path/to/worktree/.env --feature <feature-name>` from the main checkout.
+- Use the same local Postgres server at `localhost:5432`; the script creates a separate database in that server and restores a dump of the original database into it.
+- Do not create another Postgres container, do not change the Postgres port, and do not modify `docker-compose.yml` for this case.
+- Keep database names derived from the normalized feature name to avoid collisions.
+
+Before running commands:
+- Inspect the current repository path, git status, existing worktrees, and available project scripts.
+- Identify the active `.env` database and app port variables before cloning a database or writing new values.
+- Prefer existing project scripts when they already implement the required operation.
+
+After setup:
+- Report the new worktree path, branch name, copied `.env` path, dump path, and any ports or database names assigned.
+- Include the exact commands needed to start the app from the new worktree.
+- Mention anything that was intentionally skipped because the user did not request a server limpio or migration-isolated database.
+"""

--- a/docs/deploy/infraestructura.md
+++ b/docs/deploy/infraestructura.md
@@ -84,7 +84,7 @@ Las variables `NEXT_PUBLIC_*` deben inyectarse como **build args** porque Next.j
 | `NEXTAUTH_URL`            | URL base de la aplicacion para NextAuth                            |
 | `UPLOADTHING_SECRET`      | Clave secreta de UploadThing para subida de archivos               |
 | `UPLOADTHING_APP_ID`      | ID de la aplicacion en UploadThing                                 |
-| `FACTPRO_URL`             | URL de la API de FactPro para emision de comprobantes electronicos |
+| `FACTPRO_URL`             | URL de la API de FactPro v3 para emision de comprobantes electronicos (`https://api.factpro.la/api/v3`) |
 | `TELEGRAM_BOT_TOKEN`      | Token del bot de Telegram para notificaciones                      |
 | `TELEGRAM_CHAT_ID`        | ID del chat de Telegram donde se envian notificaciones             |
 | `DISCORD_BOT_TOKEN`       | Token del bot de Discord para notificaciones                       |

--- a/docs/qa-carnet-extranjeria-agent-results.md
+++ b/docs/qa-carnet-extranjeria-agent-results.md
@@ -1,0 +1,135 @@
+# QA Carnet de Extranjeria - Resultados resumidos
+
+Fecha: 2026-05-30
+Base URL: `http://localhost:3000`
+Tenant probado: `fantastidog`
+Estado general: `PARTIAL` con bug funcional `P0` confirmado
+
+## Resumen ejecutivo
+
+Se ejecuto QA funcional sobre el flujo de cliente con Carnet de Extranjeria en Nota de venta.
+
+El flujo UI permite:
+
+- abrir Nueva venta
+- crear cliente CE
+- validar maximo de 15 caracteres
+- dejar deshabilitada la busqueda externa para CE
+
+Pero se confirmo un defecto critico:
+
+- el cliente CE se persiste con `Customer.documentType = NULL`
+
+Ese defecto rompe o deja en riesgo:
+
+- reutilizacion del cliente CE en ventas posteriores
+- etiqueta correcta en voucher/PDF
+
+## Resultado por caso
+
+### CE-01 Crear nota de venta con cliente CE nuevo
+
+Estado: `PARTIAL`
+
+Validado:
+
+- En Nota de venta el modal permite `DNI` y `Carnet de extranjeria`
+- Al seleccionar CE, la busqueda externa queda deshabilitada
+- Se pudo crear un cliente CE y quedo seleccionado en la orden
+
+Observacion:
+
+- La persistencia del tipo de documento falla en DB
+
+### CE-02 Validar longitud del CE
+
+Estado: `PASS`
+
+Validado:
+
+- CE de 16 caracteres: muestra validacion `El número máximo de caracteres es 15.`
+- CE de 15 caracteres alfanumericos: permite guardar
+
+### CE-03 Reutilizar cliente CE existente
+
+Estado: `FAIL`
+
+Resultado:
+
+- Tras crear el cliente CE, al buscarlo por numero en el selector de cliente no aparece
+- Evidencia consistente con persistencia incorrecta de `documentType`
+
+### CE-04 Validar etiqueta en comprobante
+
+Estado: `AT RISK / NO CONFIRMADO EN UI`
+
+No se cerro validacion visual de voucher/PDF en esta corrida.
+
+Riesgo confirmado por logica y persistencia:
+
+- como `customer.documentType` queda `NULL`, el voucher puede caer al fallback `DNI`
+
+### CE-05 DNI en nota de venta
+
+Estado: `PASS`
+
+Validado:
+
+- El modal abre por defecto con `DNI` en Nota de venta
+
+### CE-06 Factura no permite CE
+
+Estado: `BLOCKED`
+
+Bloqueo de entorno:
+
+- `Boleta` y `Factura` estaban deshabilitadas en este tenant por configuracion de facturacion
+
+## Bug principal confirmado
+
+### P0 - Cliente CE persistido sin tipo de documento
+
+Cliente creado en QA:
+
+- `documentNumber`: `CEQA20260530001`
+- `legalName`: `QA Cliente CE Final`
+
+Consulta ejecutada:
+
+```sql
+select id, "documentType", "documentNumber", "legalName"
+from "Customer"
+where "documentNumber" = 'CEQA20260530001';
+```
+
+Resultado:
+
+- el registro existe
+- `documentType` queda `NULL`
+
+## Edge cases cubiertos
+
+- CE de 16 caracteres
+- CE alfanumerico de 15 caracteres
+- default del modal en `DNI`
+- busqueda externa deshabilitada para CE
+- busqueda posterior del cliente CE por numero
+
+## Evidencia creada
+
+- [qa-ce-01-orders-new.png](/Users/jorgegonzalez/lorito-killer/qa-ce-01-orders-new.png)
+- [qa-ce-02-modal-default-dni.png](/Users/jorgegonzalez/lorito-killer/qa-ce-02-modal-default-dni.png)
+- [qa-ce-03-validation-16-chars.png](/Users/jorgegonzalez/lorito-killer/qa-ce-03-validation-16-chars.png)
+- [qa-ce-04-customer-created-selected.png](/Users/jorgegonzalez/lorito-killer/qa-ce-04-customer-created-selected.png)
+- [qa-ce-05-selector-customer-not-found.png](/Users/jorgegonzalez/lorito-killer/qa-ce-05-selector-customer-not-found.png)
+
+## Conclusiones
+
+La funcionalidad no esta lista para cierre.
+
+Lo mas importante no es la validacion visual del modal, sino la persistencia:
+
+- el sistema deja avanzar con CE
+- pero guarda mal el dato maestro
+
+Eso convierte el flujo en inconsistente y deja roto el caso de reutilizacion, ademas de comprometer el comprobante.

--- a/docs/qa-carnet-extranjeria-fixes.md
+++ b/docs/qa-carnet-extranjeria-fixes.md
@@ -1,0 +1,181 @@
+# Fixes requeridos - Carnet de Extranjeria
+
+## Contexto
+
+Durante la validacion de `docs/qa-carnet-extranjeria.md` se comprobo que el flujo de Nota de venta con cliente CE permite completar la venta, pero persiste mal el tipo de documento del cliente.
+
+Caso reproducido en QA:
+
+- Cliente creado: `QA Cliente CE 20260530`
+- CE usado: `CE20260530AB123`
+- Venta generada: `NV01-00000001`
+- `orderId`: `7d4eb0c6-55a0-4dd0-bed8-cabc032a6d5a`
+
+Hallazgo confirmado en base de datos:
+
+- El registro en `Customer` queda con `documentType = NULL`
+- El `Order` queda asociado a ese cliente, pero sin tipo de documento persistido
+
+Esto rompe los flujos que dependen de distinguir `DNI` vs `Carnet de extranjeria`.
+
+## Problema principal
+
+El sistema deja crear y usar un cliente CE, pero no conserva su `documentType` al persistirlo. El defecto no bloquea la venta inicial, pero invalida el comportamiento esperado en reutilizacion y comprobantes.
+
+## Fix 1 - Persistir correctamente `CARNET_EXTRANJERIA`
+
+### Objetivo
+
+Garantizar que un cliente natural creado con tipo de documento CE se guarde en la tabla `Customer` con `documentType = CARNET_EXTRANJERIA`.
+
+### Impacto actual
+
+- La venta inicial parece exitosa.
+- El dato maestro del cliente queda inconsistente.
+- Cualquier logica posterior que filtre o renderice por `documentType` se rompe.
+
+### Areas a revisar
+
+- [src/customer/components/new-customer-modal.tsx](/Users/jorgegonzalez/lorito-killer/src/customer/components/new-customer-modal.tsx:84)
+- [src/customer/db_repository.ts](/Users/jorgegonzalez/lorito-killer/src/customer/db_repository.ts:41)
+- [src/customer/types.ts](/Users/jorgegonzalez/lorito-killer/src/customer/types.ts:1)
+
+### Comportamiento esperado despues del fix
+
+- Si el usuario selecciona `Carnet de extranjeria` en el modal:
+  - el customer se crea con `documentType = CARNET_EXTRANJERIA`
+  - el `documentNumber` se conserva
+  - el cliente seleccionado en la orden mantiene ese tipo
+
+### Validacion tecnica
+
+- Crear cliente CE desde Nota de venta.
+- Consultar DB y verificar:
+
+```sql
+select id, "documentType", "documentNumber", "legalName"
+from "Customer"
+where "documentNumber" = '<ce_creado>';
+```
+
+Resultado esperado:
+
+- `"documentType" = 'CARNET_EXTRANJERIA'`
+
+## Fix 2 - Permitir reutilizar clientes CE existentes
+
+### Objetivo
+
+Asegurar que un cliente CE ya creado aparezca en el selector de clientes cuando la orden es `ticket` o `receipt`.
+
+### Impacto actual
+
+El selector de clientes naturales filtra por:
+
+- `documentType === DNI`
+- `documentType === CARNET_EXTRANJERIA`
+
+Como hoy el cliente CE queda persistido con `NULL`, desaparece de ese listado y no puede reutilizarse.
+
+### Areas a revisar
+
+- [src/customer/components/customer-selector.tsx](/Users/jorgegonzalez/lorito-killer/src/customer/components/customer-selector.tsx:53)
+- [src/customer/db_repository.ts](/Users/jorgegonzalez/lorito-killer/src/customer/db_repository.ts:64)
+
+### Comportamiento esperado despues del fix
+
+- Un cliente CE existente debe aparecer al buscar por nombre.
+- Un cliente CE existente debe aparecer al buscar por numero de documento.
+- Debe poder seleccionarse y quedar asociado a una nueva Nota de venta.
+
+### Validacion funcional
+
+1. Crear cliente CE.
+2. Abrir nueva Nota de venta.
+3. Abrir selector de cliente.
+4. Buscar por nombre.
+5. Buscar por CE.
+
+Resultado esperado:
+
+- El cliente aparece en ambos casos y puede seleccionarse.
+
+## Fix 3 - Mostrar "Carnet de extranjeria" en voucher/PDF
+
+### Objetivo
+
+Corregir la etiqueta del documento del cliente en el comprobante para que use el tipo real del cliente y no haga fallback a `DNI` cuando el cliente es CE.
+
+### Impacto actual
+
+La logica del voucher hace esto:
+
+- si `customer.documentType` existe, renderiza la etiqueta correcta
+- si no existe, para Nota de venta/Boleta cae en `DNI`
+
+Con el bug actual, una venta CE puede terminar mostrando `DNI` en el comprobante.
+
+### Areas a revisar
+
+- [src/order/components/voucher.tsx](/Users/jorgegonzalez/lorito-killer/src/order/components/voucher.tsx:104)
+
+### Comportamiento esperado despues del fix
+
+- Nota de venta con cliente CE muestra `Carnet de extranjeria`.
+- No debe mostrarse `DNI` para ese cliente.
+- El numero de documento mostrado debe ser el CE ingresado.
+
+### Validacion funcional
+
+1. Crear o reutilizar cliente CE.
+2. Generar Nota de venta.
+3. Abrir voucher/PDF.
+
+Resultado esperado:
+
+- Se visualiza `Carnet de extranjeria: <numero CE>`.
+
+## Fix 4 - Agregar cobertura automatizada y/o checks de regresion
+
+### Objetivo
+
+Evitar que vuelva a romperse la persistencia del tipo de documento sin detectarlo.
+
+### Recomendacion
+
+Agregar al menos uno de estos niveles de cobertura:
+
+- test de repositorio para `createCustomer` con `CARNET_EXTRANJERIA`
+- test de integracion del flujo crear cliente natural CE
+- test E2E del flujo Nota de venta con CE
+
+### Casos minimos a cubrir
+
+- crea cliente con `documentType = CARNET_EXTRANJERIA`
+- rechaza CE de mas de 15 caracteres
+- deshabilita busqueda externa para CE
+- permite reutilizar cliente CE creado
+- muestra `Carnet de extranjeria` en comprobante
+
+## Criterios de aceptacion
+
+- `CE-01` pasa de punta a punta.
+- `CE-02` pasa con validacion exacta de 15 caracteres maximos.
+- `CE-03` pasa reutilizando cliente CE existente.
+- `CE-04` pasa mostrando la etiqueta correcta en voucher/PDF.
+- `CE-05` sigue pasando sin cambios al flujo DNI.
+- `CE-06` sigue pasando y Factura continua limitada a `RUC`.
+
+## Riesgos a revisar durante el fix
+
+- Que el fix de CE rompa el flujo actual de DNI.
+- Que el fix cambie el filtro de clientes naturales y afecte tickets/boletas existentes.
+- Que el voucher siga usando un fallback incorrecto si llega data incompleta.
+- Que exista otra capa de mapeo entre dominio y Prisma donde CE vuelva a perderse.
+
+## Orden recomendado de implementacion
+
+1. Corregir persistencia de `documentType` en creacion de cliente.
+2. Revalidar selector de clientes existentes.
+3. Revalidar render del voucher/PDF.
+4. Agregar cobertura automatizada o checklist de regresion.

--- a/docs/qa-carnet-extranjeria-remaining-verification-20260530.md
+++ b/docs/qa-carnet-extranjeria-remaining-verification-20260530.md
@@ -1,0 +1,100 @@
+# QA Carnet de Extranjeria - Verificacion restante
+
+Fecha: 2026-05-30
+Base URL: `http://localhost:3000`
+Tenant UI probado: `fantastidog`
+
+## Estado ejecutivo
+
+- CE-04 Voucher/PDF Nota de venta con cliente CE: `PASS`
+- CE-06 Factura fuerza RUC y oculta CE: `BLOCKED`
+- Estado general de esta corrida restante: `BLOCKED`
+
+El flujo restante de Nota de venta si quedo validado hasta el comprobante final. El flujo de `Factura` no pudo cerrarse porque el unico tenant disponible en el entorno local no tiene facturacion habilitada y no existe otro tenant local con `billingToken`.
+
+## Alcance ejecutado
+
+1. Login con `jorg3.594@gmail.com`
+2. Nueva venta en `fantastidog`
+3. Creacion de cliente CE nuevo:
+   - Nombre: `QA Cliente CE Voucher`
+   - Documento: `CEQA20260530031`
+4. Agregado de producto y pago de la Nota de venta
+5. Apertura automatica del documento en `/api/orders/58b179cc-1f34-40bc-9295-c4e48a4b3004/documents`
+6. Revision del comprobante renderizado
+7. Verificacion del estado de `Factura` en UI
+8. Verificacion de configuracion local en DB
+
+## Resultado por caso
+
+### CE-04 Validar etiqueta en comprobante
+
+Estado: `PASS`
+
+Resultado observado:
+
+- La venta se completo exitosamente.
+- El sistema abrio el documento de la orden en una nueva pestana.
+- En el PDF/voucher renderizado se lee:
+  - `Cliente: QA Cliente CE Voucher`
+  - `Carnet de extranjeria: CEQA20260530031`
+- No se observa fallback a `DNI`.
+
+Evidencia:
+
+- Screenshot del documento renderizado:
+  - [qa-ce-08-document-tab.png](/Users/jorgegonzalez/lorito-killer/qa-ce-08-document-tab.png)
+
+### CE-06 Factura no permite CE
+
+Estado: `BLOCKED`
+
+Bloqueo observado en UI:
+
+- En `fantastidog`, las tabs `Boleta` y `Factura` aparecen deshabilitadas en `Nueva venta`.
+- Por lo tanto no fue posible abrir el modal de nuevo cliente dentro del flujo `Factura`.
+
+Evidencia UI:
+
+- [qa-ce-09-fantastidog-factura-disabled.png](/Users/jorgegonzalez/lorito-killer/qa-ce-09-fantastidog-factura-disabled.png)
+
+Evidencia tecnica de configuracion:
+
+Consulta ejecutada en la DB local:
+
+```sql
+select subdomain,
+       case
+         when "billingCredentials" is null then false
+         else (("billingCredentials"::jsonb ->> 'billingToken') is not null)
+       end as has_billing_token
+from "Company"
+order by subdomain;
+```
+
+Resultado:
+
+```text
+  subdomain  | has_billing_token
+-------------+-------------------
+ fantastidog | f
+(1 row)
+```
+
+Conclusion del bloqueo:
+
+- El entorno local solo contiene la company `fantastidog`.
+- `fantastidog` no tiene `billingCredentials.billingToken`.
+- No existe en este entorno otra company facturable para probar `Factura` sin tocar codigo o datos de aplicacion.
+
+## Screenshots creados en esta corrida
+
+- [qa-ce-08-document-tab.png](/Users/jorgegonzalez/lorito-killer/qa-ce-08-document-tab.png)
+- [qa-ce-09-fantastidog-factura-disabled.png](/Users/jorgegonzalez/lorito-killer/qa-ce-09-fantastidog-factura-disabled.png)
+
+## Cierre
+
+La verificacion restante queda cerrada con este estado:
+
+- `PASS` para voucher/PDF de Nota de venta con cliente CE
+- `BLOCKED` para `Factura` por falta de tenant local con facturacion habilitada

--- a/prisma/migrations/20260515232425_add_product_tsvector/migration.sql
+++ b/prisma/migrations/20260515232425_add_product_tsvector/migration.sql
@@ -1,0 +1,44 @@
+CREATE EXTENSION IF NOT EXISTS unaccent;
+
+-- AlterTable
+ALTER TABLE "Product" ADD COLUMN IF NOT EXISTS "searchVector" tsvector;
+
+CREATE OR REPLACE FUNCTION product_search_vector_update()
+RETURNS trigger AS $$
+BEGIN
+  NEW."searchVector" :=
+    setweight(to_tsvector('simple', unaccent(coalesce(NEW.name, ''))), 'A') ||
+    setweight(to_tsvector('simple', unaccent(coalesce(NEW.sku, ''))), 'B') ||
+    setweight(to_tsvector('simple', unaccent(coalesce(NEW.description, ''))), 'D');
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'product_search_vector_trigger'
+      AND tgrelid = '"Product"'::regclass
+  ) THEN
+    CREATE TRIGGER product_search_vector_trigger
+    BEFORE INSERT OR UPDATE OF name, sku, description
+    ON "Product"
+    FOR EACH ROW
+    EXECUTE FUNCTION product_search_vector_update();
+  END IF;
+END;
+$$;
+
+UPDATE "Product"
+SET "searchVector" =
+  setweight(to_tsvector('simple', unaccent(coalesce(name, ''))), 'A') ||
+  setweight(to_tsvector('simple', unaccent(coalesce(sku, ''))), 'B') ||
+  setweight(to_tsvector('simple', unaccent(coalesce(description, ''))), 'D')
+WHERE "searchVector" IS NULL;
+
+CREATE INDEX IF NOT EXISTS product_search_vector_idx
+ON "Product"
+USING GIN ("searchVector");

--- a/prisma/migrations/20260530000000_add_carnet_extranjeria_customer_document_type/migration.sql
+++ b/prisma/migrations/20260530000000_add_carnet_extranjeria_customer_document_type/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "CustomerDocumentType" ADD VALUE 'CARNET_EXTRANJERIA';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -292,6 +292,7 @@ model DocumentTaxDispatch {
 enum CustomerDocumentType {
   RUC
   DNI
+  CARNET_EXTRANJERIA
 }
 
 model Customer {

--- a/scripts/clone-local-db-for-worktree.sh
+++ b/scripts/clone-local-db-for-worktree.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/clone-local-db-for-worktree.sh \
+    --source-env /path/to/main/.env \
+    --target-env /path/to/worktree/.env \
+    --feature feature-name
+
+Creates a custom-format dump of the source local database, creates a new
+database in the same local Postgres instance, restores the dump into it, and
+updates only the database name inside DATABASE_URL in the target .env.
+USAGE
+}
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+require_file() {
+  local path="$1"
+  [[ -f "${path}" ]] || die "file not found: ${path}"
+}
+
+env_value() {
+  local env_file="$1"
+  local key="$2"
+  local line value
+
+  line="$(grep -E "^[[:space:]]*${key}=" "${env_file}" | tail -n 1 || true)"
+  [[ -n "${line}" ]] || die "${key} was not found in ${env_file}"
+
+  value="${line#*=}"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+
+  if [[ "${value}" == \"*\" && "${value}" == *\" ]]; then
+    value="${value:1:${#value}-2}"
+  elif [[ "${value}" == \'*\' && "${value}" == *\' ]]; then
+    value="${value:1:${#value}-2}"
+  fi
+
+  printf '%s\n' "${value}"
+}
+
+slugify_feature() {
+  local feature="$1"
+  local slug
+
+  slug="$(printf '%s' "${feature}" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/_/g; s/^_+//; s/_+$//; s/_+/_/g')"
+
+  [[ -n "${slug}" ]] || die "feature must contain at least one alphanumeric character"
+  printf '%s\n' "${slug}"
+}
+
+parse_database_url() {
+  local url="$1"
+
+  if [[ ! "${url}" =~ ^postgres(ql)?://([^/?#]+)@([^/?#:]+)(:([0-9]+))?/([^?]+)(\?(.*))?$ ]]; then
+    die "DATABASE_URL must look like postgresql://user:password@host:port/database"
+  fi
+
+  DB_AUTH="${BASH_REMATCH[2]}"
+  DB_HOST="${BASH_REMATCH[3]}"
+  DB_PORT="${BASH_REMATCH[5]:-5432}"
+  DB_NAME="${BASH_REMATCH[6]}"
+  DB_QUERY="${BASH_REMATCH[8]:-}"
+
+  [[ "${DB_HOST}" == "localhost" || "${DB_HOST}" == "127.0.0.1" ]] \
+    || die "source DATABASE_URL must point to local Postgres, got host '${DB_HOST}'"
+  [[ "${DB_PORT}" == "5432" ]] \
+    || die "source DATABASE_URL must use local Postgres port 5432, got '${DB_PORT}'"
+  [[ -n "${DB_NAME}" ]] || die "source DATABASE_URL is missing a database name"
+}
+
+database_url_with_db() {
+  local db_name="$1"
+  local url="postgresql://${DB_AUTH}@${DB_HOST}:${DB_PORT}/${db_name}"
+
+  if [[ -n "${DB_QUERY}" ]]; then
+    url="${url}?${DB_QUERY}"
+  fi
+
+  printf '%s\n' "${url}"
+}
+
+postgres_url() {
+  database_url_with_db "postgres"
+}
+
+run_pg() {
+  if docker compose ps postgres >/dev/null 2>&1; then
+    docker compose exec -T postgres "$@"
+  else
+    command -v "$1" >/dev/null 2>&1 || die "docker compose postgres is unavailable and '$1' was not found locally"
+    "$@"
+  fi
+}
+
+update_target_env_database_url() {
+  local target_env="$1"
+  local dest_db="$2"
+  local tmp_file
+
+  tmp_file="$(mktemp "${target_env}.XXXXXX")"
+  awk -v dest_db="${dest_db}" '
+    BEGIN { updated = 0 }
+    /^[[:space:]]*DATABASE_URL=/ {
+      prefix = substr($0, 1, index($0, "="))
+      value = substr($0, index($0, "=") + 1)
+      quote = ""
+      if (value ~ /^"/ && value ~ /"$/) {
+        quote = "\""
+        value = substr(value, 2, length(value) - 2)
+      } else if (value ~ /^'\''/ && value ~ /'\''$/) {
+        quote = "'\''"
+        value = substr(value, 2, length(value) - 2)
+      }
+
+      query = ""
+      query_start = index(value, "?")
+      if (query_start > 0) {
+        query = substr(value, query_start)
+        value = substr(value, 1, query_start - 1)
+      }
+
+      slash = 0
+      for (i = length(value); i > 0; i--) {
+        if (substr(value, i, 1) == "/") {
+          slash = i
+          break
+        }
+      }
+
+      if (slash == 0) {
+        print $0
+        next
+      }
+
+      print prefix quote substr(value, 1, slash) dest_db query quote
+      updated = 1
+      next
+    }
+    { print }
+    END {
+      if (updated == 0) {
+        exit 42
+      }
+    }
+  ' "${target_env}" > "${tmp_file}" || {
+    local status=$?
+    rm -f "${tmp_file}"
+    if [[ "${status}" -eq 42 ]]; then
+      die "DATABASE_URL was not found in ${target_env}"
+    fi
+    exit "${status}"
+  }
+
+  mv "${tmp_file}" "${target_env}"
+}
+
+SOURCE_ENV=""
+TARGET_ENV=""
+FEATURE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source-env)
+      SOURCE_ENV="${2:-}"
+      shift 2
+      ;;
+    --target-env)
+      TARGET_ENV="${2:-}"
+      shift 2
+      ;;
+    --feature)
+      FEATURE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "${SOURCE_ENV}" ]] || die "--source-env is required"
+[[ -n "${TARGET_ENV}" ]] || die "--target-env is required"
+[[ -n "${FEATURE}" ]] || die "--feature is required"
+
+require_file "${SOURCE_ENV}"
+require_file "${TARGET_ENV}"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BACKUP_DIR="${ROOT_DIR}/backups"
+SOURCE_DATABASE_URL="$(env_value "${SOURCE_ENV}" "DATABASE_URL")"
+FEATURE_SLUG="$(slugify_feature "${FEATURE}")"
+DEST_DB="lorito_killer_${FEATURE_SLUG}_development"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+
+parse_database_url "${SOURCE_DATABASE_URL}"
+
+SOURCE_DB="${DB_NAME}"
+SOURCE_URL="$(database_url_with_db "${SOURCE_DB}")"
+DEST_URL="$(database_url_with_db "${DEST_DB}")"
+MAINT_URL="$(postgres_url)"
+DUMP_FILE="loritokiller_original_${SOURCE_DB}_${TIMESTAMP}.dump"
+DUMP_PATH="${BACKUP_DIR}/${DUMP_FILE}"
+
+mkdir -p "${BACKUP_DIR}"
+
+if [[ -e "${DUMP_PATH}" ]]; then
+  die "dump path already exists: ${DUMP_PATH}"
+fi
+
+if [[ "$(run_pg psql "${MAINT_URL}" -tAc "SELECT 1 FROM pg_database WHERE datname = '${DEST_DB}'")" == "1" ]]; then
+  die "destination database already exists: ${DEST_DB}"
+fi
+
+echo "Creating dump from ${SOURCE_DB}..."
+run_pg pg_dump "${SOURCE_URL}" -Fc --blobs --no-owner --no-acl > "${DUMP_PATH}"
+
+echo "Creating destination database ${DEST_DB}..."
+run_pg psql "${MAINT_URL}" -c "CREATE DATABASE \"${DEST_DB}\""
+
+echo "Restoring dump into ${DEST_DB}..."
+run_pg pg_restore --no-owner --no-acl -d "${DEST_URL}" < "${DUMP_PATH}"
+
+update_target_env_database_url "${TARGET_ENV}" "${DEST_DB}"
+
+echo
+echo "Worktree database cloned:"
+echo "  dump: ${DUMP_PATH}"
+echo "  source database: ${SOURCE_DB}"
+echo "  destination database: ${DEST_DB}"
+echo "  env updated: ${TARGET_ENV}"

--- a/src/app/[subdomain]/dashboard/layout.tsx
+++ b/src/app/[subdomain]/dashboard/layout.tsx
@@ -13,6 +13,7 @@ import { RealtimeProvider } from "@/shared/components/layout/realtime-provider";
 import { getLastOpenCashShift, userExists } from "@/cash-shift/db_repository";
 import { getCompanyFeatures } from "@/feature-flags";
 import { FeatureFlagsProvider } from "@/feature-flags/client";
+import { PrintingProvider } from "@/printing/printing-provider";
 
 export default async function DashboardLayout({
   children,
@@ -45,25 +46,27 @@ export default async function DashboardLayout({
     <CompanyProvider company={companyResponse.data}>
       <FeatureFlagsProvider features={featureFlags}>
         <RealtimeProvider>
-          <OrderFormProvider>
-            <ProductFormProvider>
-              <CategoryStoreProvider>
-                <CashShiftProvider
-                  cashShiftResponse={
-                    userPresent
-                      ? cashShiftResponse
-                      : {
-                          success: false,
-                          message: "Usuario no autenticado",
-                          type: "AuthError",
-                        }
-                  }
-                >
-                  <CategoriesLoader>{children}</CategoriesLoader>
-                </CashShiftProvider>
-              </CategoryStoreProvider>
-            </ProductFormProvider>
-          </OrderFormProvider>
+          <PrintingProvider>
+            <OrderFormProvider>
+              <ProductFormProvider>
+                <CategoryStoreProvider>
+                  <CashShiftProvider
+                    cashShiftResponse={
+                      userPresent
+                        ? cashShiftResponse
+                        : {
+                            success: false,
+                            message: "Usuario no autenticado",
+                            type: "AuthError",
+                          }
+                    }
+                  >
+                    <CategoriesLoader>{children}</CategoriesLoader>
+                  </CashShiftProvider>
+                </CategoryStoreProvider>
+              </ProductFormProvider>
+            </OrderFormProvider>
+          </PrintingProvider>
         </RealtimeProvider>
       </FeatureFlagsProvider>
     </CompanyProvider>

--- a/src/app/api/orders/[id]/print-data/route.ts
+++ b/src/app/api/orders/[id]/print-data/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+
+import { getCompany } from "@/company/db_repository";
+import { findBillingDocumentFor } from "@/document/db_repository";
+import { getSession } from "@/lib/auth";
+import { errorResponse } from "@/lib/utils";
+import { find } from "@/order/db_repository";
+import { buildReceiptPrintData } from "@/printing/receipt-builder";
+
+export async function GET(
+  _req: Request,
+  props: { params: Promise<{ id: string }> },
+) {
+  const params = await props.params;
+  const session = await getSession();
+
+  if (!session.user) {
+    return NextResponse.json(
+      { success: false, message: "Unauthenticated user" },
+      { status: 401 },
+    );
+  }
+
+  const [companyResponse, orderResponse, documentResponse] = await Promise.all([
+    getCompany(session.user.companyId),
+    find(params.id, session.user.companyId),
+    findBillingDocumentFor(params.id),
+  ]);
+
+  if (!companyResponse.success) {
+    return NextResponse.json(errorResponse("No se encontro empresa"), {
+      status: 404,
+    });
+  }
+
+  if (!orderResponse.success || !documentResponse.success) {
+    return NextResponse.json(
+      errorResponse("No se encontro pedido o documento"),
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json({
+    success: true,
+    data: buildReceiptPrintData({
+      order: orderResponse.data,
+      company: companyResponse.data,
+      document: documentResponse.data,
+    }),
+  });
+}

--- a/src/customer/components/customer-selector.tsx
+++ b/src/customer/components/customer-selector.tsx
@@ -17,7 +17,13 @@ import {
   CommandItem,
   CommandList,
 } from "@/shared/components/ui/command";
-import { CustomerType, DNI, InferCustomerType, RUC } from "@/customer/types";
+import {
+  CARNET_EXTRANJERIA,
+  CustomerType,
+  DNI,
+  InferCustomerType,
+  RUC,
+} from "@/customer/types";
 import { getMany } from "@/customer/api_repository";
 import * as React from "react";
 import { useEffect, useState } from "react";
@@ -45,7 +51,9 @@ export default function CustomerSelector<T extends CustomerType | undefined>({
   const { toast } = useToast();
 
   const naturalCustomer = customers.filter(
-    (customer) => customer.documentType === DNI,
+    (customer) =>
+      customer.documentType === DNI ||
+      customer.documentType === CARNET_EXTRANJERIA,
   );
   const businessCustomer = customers.filter(
     (customer) => customer.documentType === RUC,
@@ -103,7 +111,7 @@ export default function CustomerSelector<T extends CustomerType | undefined>({
         <Command shouldFilter={false}>
           <CommandInput
             value={search}
-            placeholder="Nombre o dni de cliente"
+            placeholder="Nombre o documento de cliente"
             onValueChange={setSearch}
           />
           <CommandList>

--- a/src/customer/components/new-customer-modal.tsx
+++ b/src/customer/components/new-customer-modal.tsx
@@ -23,9 +23,14 @@ import {
 import { Plus, Search } from "lucide-react";
 import { Button } from "@/shared/components/ui/button";
 import { Input } from "@/shared/components/ui/input";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { type Customer, DNI, RUC } from "@/customer/types";
+import {
+  CARNET_EXTRANJERIA,
+  type Customer,
+  DNI,
+  RUC,
+} from "@/customer/types";
 import {
   Select,
   SelectContent,
@@ -44,12 +49,11 @@ import { useEffect, useState } from "react";
 import { createCustomer, searchCustomer } from "@/customer/actions";
 import DistrictSelector from "@/locality/components/district_selector";
 import { District } from "@/locality/types";
+import { type DocumentType } from "@/document/types";
 
 const CustomerSchema = z.object({
-  documentType: z.enum([DNI, RUC]).optional(),
-  documentNumber: z.coerce
-    .string()
-    .max(11, { message: "El número máximo de dígitos es 11." }),
+  documentType: z.enum([DNI, CARNET_EXTRANJERIA, RUC]),
+  documentNumber: z.coerce.string(),
   geoCode: z.string().optional(),
   fullName: z.string().min(3, {
     message: "El nombre del cliente debe tener al menos 3 caracteres",
@@ -57,20 +61,39 @@ const CustomerSchema = z.object({
   address: z.string().optional(),
   email: z.string().optional(),
   phoneNumber: z.string().optional(),
+}).superRefine((values, ctx) => {
+  const maxLength = values.documentType === CARNET_EXTRANJERIA ? 15 : 11;
+
+  if (values.documentNumber.length > maxLength) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.too_big,
+      maximum: maxLength,
+      type: "string",
+      inclusive: true,
+      path: ["documentNumber"],
+      message: `El número máximo de caracteres es ${maxLength}.`,
+    });
+  }
 });
 
 type CustomerFormValues = z.infer<typeof CustomerSchema>;
+
+const defaultCustomerDocumentType = (documentType: DocumentType) =>
+  documentType === "receipt" || documentType === "ticket" ? DNI : RUC;
 
 const formValuesToCustomer = (
   values: CustomerFormValues,
   companyId: string,
 ): Customer => {
-  if (values.documentType === DNI) {
+  if (
+    values.documentType === DNI ||
+    values.documentType === CARNET_EXTRANJERIA
+  ) {
     return {
       _branch: "NaturalCustomer",
       id: crypto.randomUUID(),
       companyId: companyId,
-      documentType: DNI,
+      documentType: values.documentType,
       documentNumber: values.documentNumber.toString(),
       geoCode: values.geoCode || "",
       fullName: values.fullName,
@@ -100,6 +123,15 @@ const formValuesToCustomer = (
 export default function NewCustomerModal() {
   const form = useForm<CustomerFormValues>({
     resolver: zodResolver(CustomerSchema),
+    defaultValues: {
+      documentType: defaultCustomerDocumentType("ticket"),
+      documentNumber: "",
+      geoCode: "",
+      fullName: "",
+      address: "",
+      email: "",
+      phoneNumber: "",
+    },
   });
   const order = useOrderFormStore((state) => state.order);
   const [open, setOpen] = useState(false);
@@ -107,10 +139,19 @@ export default function NewCustomerModal() {
   const user = useUserSession();
   const [locality, setLocality] = useState<District | undefined>();
   const { setCustomer } = useOrderFormActions();
+  const selectedDocumentType = useWatch({
+    control: form.control,
+    name: "documentType",
+  });
 
   const onSubmit = async (data: CustomerFormValues) => {
+    const customerDocumentType =
+      data.documentType ?? selectedDocumentType ?? defaultCustomerDocumentType(order.documentType);
     const res = await createCustomer(
-      formValuesToCustomer(data, user!.companyId!),
+      formValuesToCustomer(
+        { ...data, documentType: customerDocumentType },
+        user!.companyId!,
+      ),
     );
     if (res.success) {
       toast({
@@ -132,12 +173,19 @@ export default function NewCustomerModal() {
   const handleDialogChange = (isOpen: boolean) => {
     if (!isOpen) {
       form.reset();
+    } else {
+      form.setValue(
+        "documentType",
+        defaultCustomerDocumentType(order.documentType),
+      );
     }
     setOpen(isOpen);
   };
 
   const handleSearch = async () => {
-    const documentNumberSearch = form.watch("documentNumber");
+    if (selectedDocumentType === CARNET_EXTRANJERIA) return;
+
+    const documentNumberSearch = form.getValues("documentNumber");
     const res = await searchCustomer(
       String(documentNumberSearch),
       order.documentType,
@@ -171,11 +219,10 @@ export default function NewCustomerModal() {
   };
 
   useEffect(() => {
-    const defaultDocumentType =
-      order.documentType === "receipt" || order.documentType === "ticket"
-        ? DNI
-        : RUC;
-    form.setValue("documentType", defaultDocumentType);
+    form.setValue(
+      "documentType",
+      defaultCustomerDocumentType(order.documentType),
+    );
   }, [order.documentType, form]);
 
   return (
@@ -214,6 +261,7 @@ export default function NewCustomerModal() {
                   type="button"
                   className="mt-8 md:h-10 md:w-14 flex md:mt-8 items-center md:px-4"
                   onClick={handleSearch}
+                  disabled={selectedDocumentType === CARNET_EXTRANJERIA}
                 >
                   <Search/>
                 </Button>
@@ -226,13 +274,8 @@ export default function NewCustomerModal() {
                       <FormLabel>Tipo de Documento</FormLabel>
                       <Select
                         onValueChange={field.onChange}
-                        defaultValue={
-                          order.documentType === "receipt" ||
-                          order.documentType === "ticket"
-                            ? DNI
-                            : RUC
-                        }
-                        disabled
+                        value={field.value}
+                        disabled={order.documentType === "invoice"}
                       >
                         <FormControl>
                           <SelectTrigger>
@@ -242,7 +285,12 @@ export default function NewCustomerModal() {
                         <SelectContent>
                           {order.documentType === "receipt" ||
                           order.documentType === "ticket" ? (
-                            <SelectItem value={DNI}>DNI</SelectItem>
+                            <>
+                              <SelectItem value={DNI}>DNI</SelectItem>
+                              <SelectItem value={CARNET_EXTRANJERIA}>
+                                Carnet de extranjería
+                              </SelectItem>
+                            </>
                           ) : (
                             <SelectItem value={RUC}>RUC</SelectItem>
                           )}

--- a/src/customer/db_repository.ts
+++ b/src/customer/db_repository.ts
@@ -1,5 +1,6 @@
 import {
   BusinessCustomer,
+  CARNET_EXTRANJERIA,
   type Customer,
   CustomerDocumentType,
   DNI,
@@ -10,22 +11,47 @@ import {
 } from "@/customer/types";
 import { response } from "@/lib/types";
 import prisma from "@/lib/prisma";
-import { $Enums, Customer as PrismaCustomer, Prisma } from "@prisma/client";
+import {
+  Customer as PrismaCustomer,
+  CustomerDocumentType as PrismaCustomerDocumentType,
+  Prisma,
+} from "@prisma/client";
 import { isBusinessCustomer, isNaturalCustomer } from "@/customer/utils";
-import PrismaCustomerDocumentType = $Enums.CustomerDocumentType;
 
 const CustomerDocumentTypeToPrismaMapper: Record<
   CustomerDocumentType,
   PrismaCustomerDocumentType
 > = {
+  [CARNET_EXTRANJERIA]: PrismaCustomerDocumentType.CARNET_EXTRANJERIA,
   [DNI]: PrismaCustomerDocumentType.DNI,
   [RUC]: PrismaCustomerDocumentType.RUC,
+};
+
+const prismaToNaturalCustomerDocumentType = (
+  documentType: PrismaCustomerDocumentType | null,
+): NaturalCustomer["documentType"] => {
+  if (documentType === PrismaCustomerDocumentType.CARNET_EXTRANJERIA) {
+    return CARNET_EXTRANJERIA;
+  }
+
+  if (documentType === PrismaCustomerDocumentType.DNI) {
+    return DNI;
+  }
+
+  return undefined;
 };
 
 export const createCustomer = async (
   customer: Customer,
 ): Promise<response<Customer>> => {
   try {
+    if (isNaturalCustomer(customer) && !customer.documentType) {
+      return {
+        success: false,
+        message: "Natural customer document type is required",
+      };
+    }
+
     const documentType = customer.documentType
       ? CustomerDocumentTypeToPrismaMapper[customer.documentType]
       : undefined;
@@ -82,7 +108,9 @@ export const createCustomer = async (
         _branch: "NaturalCustomer",
         id: customerCreatedResponse.id,
         companyId: customerCreatedResponse.companyId,
-        documentType: "dni",
+        documentType: prismaToNaturalCustomerDocumentType(
+          customerCreatedResponse.documentType,
+        ),
         documentNumber: customerCreatedResponse.documentNumber!,
         geoCode: customerCreatedResponse.geoCode || undefined,
         fullName: customerCreatedResponse.legalName!,
@@ -130,7 +158,7 @@ export const findByDocumentNumber = async (
       where: { documentNumber, companyId },
     });
 
-    if (customer) {
+    if (customer.length > 0) {
       return { success: true, data: await prismaToCustomer(customer[0]) };
     } else {
       return { success: false, message: "Customer not found" };
@@ -212,7 +240,9 @@ export const prismaToCustomer = async (
       _branch: "NaturalCustomer",
       id: prismaCustomer.id,
       companyId: prismaCustomer.companyId,
-      documentType: "dni",
+      documentType: prismaToNaturalCustomerDocumentType(
+        prismaCustomer.documentType,
+      ),
       documentNumber: prismaCustomer.documentNumber!,
       fullName: prismaCustomer.legalName!,
       address: prismaCustomer.address!,

--- a/src/customer/types.ts
+++ b/src/customer/types.ts
@@ -2,17 +2,24 @@ export const DNI = "dni";
 
 export type DniType = typeof DNI;
 
+export const CARNET_EXTRANJERIA = "carnet_extranjeria";
+
+export type CarnetExtranjeriaType = typeof CARNET_EXTRANJERIA;
+
 export const RUC = "ruc";
 
 export type RucType = typeof RUC;
 
-export type CustomerDocumentType = DniType | RucType;
+export type CustomerDocumentType =
+  | DniType
+  | CarnetExtranjeriaType
+  | RucType;
 
 export type NaturalCustomer = {
   _branch: "NaturalCustomer";
   id: string;
   companyId: string;
-  documentType?: DniType;
+  documentType?: DniType | CarnetExtranjeriaType;
   documentNumber?: string;
   geoCode?: string;
   fullName: string;

--- a/src/document/factpro/gateway.ts
+++ b/src/document/factpro/gateway.ts
@@ -16,7 +16,12 @@ import {
   FactproResponseV3,
 } from "@/document/factpro/types";
 import { log } from "@/lib/log";
-import { BusinessCustomer, Customer, NaturalCustomer } from "@/customer/types";
+import {
+  BusinessCustomer,
+  CARNET_EXTRANJERIA,
+  Customer,
+  NaturalCustomer,
+} from "@/customer/types";
 import { isBusinessCustomer } from "@/customer/utils";
 import {
   DocumentGateway,
@@ -61,8 +66,15 @@ function clientParamsBuilder(
     };
   }
 
+  const clienteTipoDocumento =
+    customer.documentType === CARNET_EXTRANJERIA
+      ? "3"
+      : customer.documentNumber
+        ? "2"
+        : "1";
+
   return {
-    cliente_tipo_documento: customer.documentNumber ? "2" : "1",
+    cliente_tipo_documento: clienteTipoDocumento,
     cliente_numero_documento: customer.documentNumber || "00000000",
     cliente_denominacion: customer.fullName,
     cliente_direccion: customer.address || "-",

--- a/src/document/factpro/gateway.ts
+++ b/src/document/factpro/gateway.ts
@@ -1,6 +1,5 @@
 import { Order, OrderItem, OrderWithBusinessCustomer } from "@/order/types";
 import { response } from "@/lib/types";
-import { format, parse } from "date-fns";
 import {
   Invoice,
   Receipt,
@@ -8,12 +7,13 @@ import {
   Document,
   RegisteredTicket,
   RegisteredInvoince,
-  RegisteredReceipt
+  RegisteredReceipt,
 } from "@/document/types";
 import {
-  FactproDocument, FactproDocumentConsult,
-  FactproDocumentItem,
-  FactproResponse,
+  FactproCancelResponseV3,
+  FactproDocumentItemV3,
+  FactproDocumentV3,
+  FactproResponseV3,
 } from "@/document/factpro/types";
 import { log } from "@/lib/log";
 import { BusinessCustomer, Customer, NaturalCustomer } from "@/customer/types";
@@ -23,22 +23,27 @@ import {
   DocumentMetadata,
 } from "@/document/use_cases/create-document";
 import { formatInTimeZone } from "date-fns-tz";
-import {div, errorResponse} from "@/lib/utils";
-import {findDocument, update as updateDocument} from "@/document/db_repository";
-import {isInvoice, isReceipt} from "@/document/utils";
+import { errorResponse } from "@/lib/utils";
+import { update as updateDocument } from "@/document/db_repository";
+import { isInvoice, isReceipt } from "@/document/utils";
 
 const url = process.env.FACTPRO_URL;
 
+const factproEndpoint = (path: "documentos" | "anular") => {
+  if (!url) return `/${path}`;
+  return `${url.replace(/\/$/, "")}/${path}`;
+};
+
+const FACTPRO_DOCUMENT_ERROR = "Error al crear el documento en FactPro";
+
 function clientParamsBuilder(
   customer: Customer | undefined,
-): FactproDocument["cliente"] {
+): FactproDocumentV3["cliente"] {
   if (!customer) {
     return {
       cliente_tipo_documento: "1",
-      cliente_numero_documento: "11111111",
+      cliente_numero_documento: "00000000",
       cliente_denominacion: "Clientes Varios",
-      codigo_pais: "PE",
-      ubigeo: "",
       cliente_direccion: "-",
       cliente_telefono: "",
       cliente_email: "",
@@ -47,11 +52,9 @@ function clientParamsBuilder(
 
   if (isBusinessCustomer(customer)) {
     return {
-      cliente_tipo_documento: "6",
+      cliente_tipo_documento: "4",
       cliente_numero_documento: customer.documentNumber,
       cliente_denominacion: customer.legalName,
-      codigo_pais: "PE",
-      ubigeo: customer.geoCode,
       cliente_direccion: customer.address,
       cliente_email: customer.email,
       cliente_telefono: customer.phoneNumber,
@@ -59,11 +62,9 @@ function clientParamsBuilder(
   }
 
   return {
-    cliente_tipo_documento: "1",
+    cliente_tipo_documento: customer.documentNumber ? "2" : "1",
     cliente_numero_documento: customer.documentNumber || "00000000",
     cliente_denominacion: customer.fullName,
-    codigo_pais: "PE",
-    ubigeo: customer.geoCode || "",
     cliente_direccion: customer.address || "-",
     cliente_email: customer.email || "",
     cliente_telefono: customer.phoneNumber || "",
@@ -71,12 +72,12 @@ function clientParamsBuilder(
 }
 
 const sendDocument = async (
-  body: FactproDocument,
+  body: FactproDocumentV3,
   orderId: string,
   token: string,
-): Promise<response<FactproResponse>> => {
+): Promise<response<FactproResponseV3>> => {
   const startDate = new Date();
-  const endpoint = `${url!}/documentos`;
+  const endpoint = factproEndpoint("documentos");
   log.info("sending_factpro_document", { orderId, document: body });
   const res = await fetch(endpoint, {
     method: "POST",
@@ -89,9 +90,9 @@ const sendDocument = async (
 
   const responseBody = await res.text();
 
-  let resJson: FactproResponse;
+  let resJson: FactproResponseV3;
   try {
-    resJson = JSON.parse(responseBody) as FactproResponse;
+    resJson = JSON.parse(responseBody) as FactproResponseV3;
   } catch {
     log.error("factpro_document_processed", {
       status: "error",
@@ -108,7 +109,7 @@ const sendDocument = async (
     };
   }
 
-  if (res.status === 200 && resJson.success) {
+  if (res.ok && resJson.exito) {
     log.info("factpro_document_processed", {
       status: "success",
       document: body,
@@ -122,8 +123,7 @@ const sendDocument = async (
   }
 
   const errorMessage =
-    (!resJson.success && resJson.message) ||
-    "Error al crear el documento en FactPro";
+    (!resJson.exito && resJson.mensaje) || FACTPRO_DOCUMENT_ERROR;
 
   log.error("factpro_document_processed", {
     status: "error",
@@ -140,37 +140,32 @@ const sendDocument = async (
   };
 };
 
-const orderItemToDocumentItem = (orderItem: OrderItem): FactproDocumentItem => {
-  const item: FactproDocumentItem = {
+const orderItemToDocumentItem = (
+  orderItem: OrderItem,
+): FactproDocumentItemV3 => {
+  const item: FactproDocumentItemV3 = {
     unidad: "NIU",
     codigo: orderItem.productSku || "",
     descripcion: orderItem.productName,
     cantidad: orderItem.quantity,
-    valor_unitario: orderItem.productPrice,
-    precio_unitario: orderItem.productPrice,
-    codigo_producto_sunat: "",
-    codigo_producto_gsl: "",
+    precio: orderItem.productPrice,
+    incluye_tax: true,
     tipo_tax: "20", // Exonerado - Operación Onerosa
-    total_base_tax: orderItem.total,
-    porcentaje_tax: 0, // All products are exonerated in Pucallpa
-    total_tax: 0,
-    total: orderItem.total,
   };
 
   if (orderItem.discountAmount) {
-    item.descuentos = {
-      codigo: "00",
-      descripcion: "Descuento",
-      porcentaje: parseFloat(
-        div(orderItem.discountAmount)(orderItem.netTotal).toFixed(4),
-      ),
-      monto: orderItem.discountAmount,
-      base: orderItem.netTotal,
-    };
+    item.descuento = orderItem.discountAmount;
   }
 
   return item;
 };
+
+const orderTotals = (order: Order) => ({
+  totalExoneradas: order.total,
+  totalTax: 0,
+  totalVenta: order.total,
+  discountAmount: order.discount ? order.discountAmount : 0,
+});
 
 // Api documentation https://docs.factpro.la/
 export default function gateway({
@@ -188,7 +183,7 @@ export default function gateway({
   ) => Promise<response<NaturalCustomer>>;
   cancelDocument: (
     document: Document,
-    cancellationReason: string
+    cancellationReason: string,
   ) => Promise<response<Document>>;
 } {
   const createInvoice = async (
@@ -199,67 +194,42 @@ export default function gateway({
       return { success: false, message: "Billing token not found" };
     }
 
-    const body: FactproDocument = {
-      tipo_documento: "01",
+    const totals = orderTotals(order);
+    const body: FactproDocumentV3 = {
       serie: documentMetadata.serialNumber,
       numero: documentMetadata.documentNumber.toString(),
-      tipo_operacion: "0101", // By default
+      tipo_operacion: "1",
       fecha_de_emision: formatInTimeZone(
         order.createdAt,
         "America/Lima",
         "yyyy-MM-dd",
       ),
-      hora_de_emision: formatInTimeZone(
-        order.createdAt,
-        "America/Lima",
-        "hh:mm:ss",
-      ),
       moneda: "PEN",
       enviar_automaticamente_al_cliente: false,
-      datos_del_emisor: {
-        codigo_establecimiento: documentMetadata.establishmentCode,
-      },
       cliente: clientParamsBuilder(order.customer),
-      totales: {
-        total_exoneradas: order.total,
-        total_tax: 0,
-        total_venta: order.total,
-        total_gravadas: 0,
-        total_exportacion: 0,
-        total_inafectas: 0,
-        total_gratuitas: 0,
-        descuentos: order.discount && {
-          codigo: "02",
-          descripcion: "Descuento general",
-          porcentaje: div(order.discountAmount)(order.netTotal),
-          monto: order.discountAmount,
-          base: order.netTotal,
-        },
-      },
       items: order.orderItems.map((orderItem) =>
         orderItemToDocumentItem(orderItem),
       ),
-      acciones: {
-        formato_pdf: "a4",
-      },
-      termino_de_pago: {
-        descripcion: "Contado",
-        tipo: "0",
-      },
-      metodo_de_pago: "Efectivo", // agregar metodo de pago
-      canal_de_venta: "",
-      orden_de_compra: "",
-      almacen: "",
+      condicion_de_pago: [
+        {
+          tipo_de_condicion: "0",
+          forma_de_pago: "0",
+          monto: 0,
+        },
+      ],
+      ...(order.discount
+        ? { totales: { monto_descuento_global: order.discountAmount } }
+        : {}),
       observaciones: "",
-      fecha_de_vencimiento: "",
+      formato_pdf: "a4",
     };
 
     const response = await sendDocument(body, order.id!, billingToken);
     if (!response.success) return response;
-    if (!response.data.success)
+    if (!response.data.exito)
       return {
         success: false,
-        message: response.data.message || "Error al crear el documento en FactPro",
+        message: response.data.mensaje || FACTPRO_DOCUMENT_ERROR,
       };
 
     return {
@@ -269,14 +239,14 @@ export default function gateway({
         orderId: order.id!,
         companyId: order.companyId,
         customerId: order.customer.id!,
-        netTotal: body.totales.total_exoneradas,
-        taxTotal: body.totales.total_tax,
-        discountAmount: body.totales.descuentos?.monto || 0,
-        total: body.totales.total_venta,
+        netTotal: totals.totalExoneradas,
+        taxTotal: totals.totalTax,
+        discountAmount: totals.discountAmount,
+        total: totals.totalVenta,
         documentType: "invoice",
         series: body.serie,
         number: body.numero,
-        xml: response.data.links.xml,
+        xml: response.data.archivos.xml,
         status: "registered",
         qr: response.data.data.qr,
         hash: response.data.data.hash,
@@ -293,67 +263,42 @@ export default function gateway({
       return { success: false, message: "Billing token not found" };
     }
 
-    const body: FactproDocument = {
-      tipo_documento: "03",
+    const totals = orderTotals(order);
+    const body: FactproDocumentV3 = {
       serie: documentMetadata.serialNumber,
       numero: documentMetadata.documentNumber.toString(),
-      tipo_operacion: "0101", // By default
+      tipo_operacion: "1",
       fecha_de_emision: formatInTimeZone(
         order.createdAt,
         "America/Lima",
         "yyyy-MM-dd",
       ),
-      hora_de_emision: formatInTimeZone(
-        order.createdAt,
-        "America/Lima",
-        "hh:mm:ss",
-      ),
       moneda: "PEN",
       enviar_automaticamente_al_cliente: false,
-      datos_del_emisor: {
-        codigo_establecimiento: documentMetadata.establishmentCode,
-      },
       cliente: clientParamsBuilder(order.customer),
-      totales: {
-        total_exoneradas: order.total,
-        total_tax: 0,
-        total_venta: order.total,
-        total_gravadas: 0,
-        total_exportacion: 0,
-        total_inafectas: 0,
-        total_gratuitas: 0,
-        descuentos: order.discount && {
-          codigo: "02",
-          descripcion: "Descuento general",
-          porcentaje: div(order.discountAmount)(order.netTotal),
-          monto: order.discountAmount,
-          base: order.netTotal,
-        },
-      },
       items: order.orderItems.map((orderItem) =>
         orderItemToDocumentItem(orderItem),
       ),
-      acciones: {
-        formato_pdf: "a4",
-      },
-      termino_de_pago: {
-        descripcion: "Contado",
-        tipo: "0",
-      },
-      metodo_de_pago: "Efectivo", // agregar metodo de pago
-      canal_de_venta: "",
-      orden_de_compra: "",
-      almacen: "",
+      condicion_de_pago: [
+        {
+          tipo_de_condicion: "0",
+          forma_de_pago: "0",
+          monto: 0,
+        },
+      ],
+      ...(order.discount
+        ? { totales: { monto_descuento_global: order.discountAmount } }
+        : {}),
       observaciones: "",
-      fecha_de_vencimiento: "",
+      formato_pdf: "a4",
     };
 
     const response = await sendDocument(body, order.id!, billingToken);
     if (!response.success) return response;
-    if (!response.data.success)
+    if (!response.data.exito)
       return {
         success: false,
-        message: response.data.message || "Error al crear el documento en FactPro",
+        message: response.data.mensaje || FACTPRO_DOCUMENT_ERROR,
       };
 
     return {
@@ -363,14 +308,14 @@ export default function gateway({
         orderId: order.id!,
         companyId: order.companyId,
         customerId: order.customer?.id!,
-        netTotal: body.totales.total_exoneradas,
-        taxTotal: body.totales.total_tax,
-        discountAmount: body.totales.descuentos?.monto || 0,
-        total: body.totales.total_venta,
+        netTotal: totals.totalExoneradas,
+        taxTotal: totals.totalTax,
+        discountAmount: totals.discountAmount,
+        total: totals.totalVenta,
         documentType: "receipt",
         series: body.serie,
         number: body.numero,
-        xml: response.data.links.xml,
+        xml: response.data.archivos.xml,
         status: "registered",
         qr: response.data.data.qr,
         hash: response.data.data.hash,
@@ -505,29 +450,40 @@ export default function gateway({
     };
   };
 
-  const cancelTicket = async (document: Ticket, cancellationReason: string): Promise<response<Document>> => {
-    const updatedDocument = await updateDocument({...document,cancellationReason: cancellationReason, status: 'cancelled'})
-    if(!updatedDocument.success){
-      log.error("update_document_failed",{document, updatedDocument})
-      return errorResponse('Update document failed')
+  const cancelTicket = async (
+    document: Ticket,
+    cancellationReason: string,
+  ): Promise<response<Document>> => {
+    const updatedDocument = await updateDocument({
+      ...document,
+      cancellationReason: cancellationReason,
+      status: "cancelled",
+    });
+    if (!updatedDocument.success) {
+      log.error("update_document_failed", { document, updatedDocument });
+      return errorResponse("Update document failed");
     }
 
-    return {success: true, data: updatedDocument.data}
-  }
+    return { success: true, data: updatedDocument.data };
+  };
 
-  const cancelBillingDocument = async (document: Invoice | Receipt, cancellationReason: string): Promise<response<Document>> => {
-    if (document.status != 'registered') {
-      throw new Error('Invalid document, only registered documents are supported')
+  const cancelBillingDocument = async (
+    document: Invoice | Receipt,
+    cancellationReason: string,
+  ): Promise<response<Document>> => {
+    if (document.status != "registered") {
+      throw new Error(
+        "Invalid document, only registered documents are supported",
+      );
     }
 
     const body = {
-      tipo_documento: isInvoice(document) ? "01" : '03',
       serie: document.series,
       numero: document.number,
       motivo: cancellationReason,
     };
 
-    const res = await fetch(`${url!}/anular`, {
+    const res = await fetch(factproEndpoint("anular"), {
       method: "POST",
       headers: {
         Authorization: `Bearer ${billingToken}`,
@@ -536,21 +492,46 @@ export default function gateway({
       body: JSON.stringify(body),
     });
 
-    const result = await res.json();
-    if (!result.success) {
-      log.error('cancel_factpro_document_failed', { document, result });
-      return errorResponse(result.message);
+    const responseBody = await res.text();
+    let result: FactproCancelResponseV3;
+    try {
+      result = JSON.parse(responseBody) as FactproCancelResponseV3;
+    } catch {
+      log.error("cancel_factpro_document_failed", {
+        document,
+        response_body: responseBody,
+        error: "format_error",
+      });
+      return errorResponse("FactPro devolvió una respuesta no JSON");
     }
 
-    log.info('cancel_factpro_document_succeeded', { document, result });
-    return { success: true, data: { ...document, status: 'cancelled', cancellationReason: cancellationReason } };
+    if (!res.ok || !result.exito) {
+      log.error("cancel_factpro_document_failed", { document, result });
+      return errorResponse(
+        result.mensaje || "Error al anular el documento en FactPro",
+      );
+    }
+
+    log.info("cancel_factpro_document_succeeded", { document, result });
+    return {
+      success: true,
+      data: {
+        ...document,
+        status: "cancelled",
+        cancellationReason: cancellationReason,
+      },
+    };
   };
 
-  const cancelDocument = async (document: Document, cancellationReason: string): Promise<response<Document>> => {
-    if (isReceipt(document) || isInvoice(document)) return cancelBillingDocument(document, cancellationReason)
+  const cancelDocument = async (
+    document: Document,
+    cancellationReason: string,
+  ): Promise<response<Document>> => {
+    if (isReceipt(document) || isInvoice(document))
+      return cancelBillingDocument(document, cancellationReason);
 
-    return cancelTicket(document, cancellationReason)
-  }
+    return cancelTicket(document, cancellationReason);
+  };
 
   return {
     createInvoice,

--- a/src/document/factpro/types.ts
+++ b/src/document/factpro/types.ts
@@ -19,8 +19,8 @@ export interface FactproDocumentV3 {
   moneda: "PEN" | "USD";
   enviar_automaticamente_al_cliente?: boolean;
   cliente: {
-    // FactPro v3 catalog: 4 = RUC, 2 = DNI, 1 = Otros
-    cliente_tipo_documento: "4" | "2" | "1";
+    // FactPro v3 catalog: 4 = RUC, 3 = CE, 2 = DNI, 1 = Otros
+    cliente_tipo_documento: "4" | "3" | "2" | "1";
     cliente_numero_documento: string;
     cliente_denominacion: string;
     cliente_direccion: string;

--- a/src/document/factpro/types.ts
+++ b/src/document/factpro/types.ts
@@ -1,144 +1,95 @@
-export interface FactproDocumentItem {
-  // NIU = PRODUCTO
-  // ZZ = SERVICIO
+export interface FactproDocumentItemV3 {
   unidad: "NIU";
   codigo: string;
-  descripcion: string; // product name
+  descripcion: string;
   cantidad: number;
-  valor_unitario: number; // without igv
-  precio_unitario: number; // with igv
-  // 10 = Gravado - Operación Onerosa
-  // 20= Exonerado - Operación Onerosa
-  tipo_tax: "10" | "20";
-  total_base_tax: number;
-  codigo_producto_sunat: string;
-  codigo_producto_gsl: string;
-  porcentaje_tax: 18 | 0;
-  total_tax: number;
-  total: number;
-  descuentos?: {
-    codigo: string;
-    descripcion: string;
-    porcentaje: number;
-    monto: number;
-    base: number;
-  };
+  precio: number;
+  incluye_tax: true;
+  // 1 = Gravado - Operacion Onerosa
+  // 20 = Exonerado - Operacion Onerosa
+  tipo_tax: "1" | "20";
+  descuento?: number;
 }
 
-export interface FactproDocument {
-  tipo_documento: "01" | "03" | "07" | "08"; // 01 = Factura, 03 = Boleta, 07 = Nota de Crédito, 08 = Nota de Débito
+export interface FactproDocumentV3 {
   serie: string;
   numero: string;
-  tipo_operacion: "0101"; // by default is 0101
-  fecha_de_emision: string; // example 2024-05-14
-  hora_de_emision: string; // example 10:11:11
+  tipo_operacion: "1";
+  fecha_de_emision: string;
   moneda: "PEN" | "USD";
-  fecha_de_vencimiento?: string; // example 2024-05-14
   enviar_automaticamente_al_cliente?: boolean;
-  datos_del_emisor: {
-    codigo_establecimiento: string;
-  };
   cliente: {
-    // 6 = RUC - REGISTRO ÚNICO DE CONTRIBUYENTE
-    // 1 = DNI - DOC. NACIONAL DE IDENTIDAD
-    // 4 = CARNET DE EXTRANJERÍA
-    // 7 = PASAPORTE
-    // A = CÉDULA DIPLOMÁTICA DE IDENTIDAD
-    // 0 = NO DOMICILIADO, SIN RUC
-    cliente_tipo_documento: "6" | "1" | "4" | "7" | "A" | "0";
+    // FactPro v3 catalog: 4 = RUC, 2 = DNI, 1 = Otros
+    cliente_tipo_documento: "4" | "2" | "1";
     cliente_numero_documento: string;
-    cliente_denominacion: string; // legal name
-    codigo_pais: "PE";
-    ubigeo: string;
+    cliente_denominacion: string;
     cliente_direccion: string;
     cliente_email?: string;
     cliente_telefono: string;
   };
-  totales: {
-    total_venta: number;
-    total_tax: number;
-    total_exoneradas: number;
-    total_exportacion: number;
-    total_gravadas: number;
-    total_inafectas: number;
-    total_gratuitas: number;
-    descuentos?: {
-      codigo: string;
-      descripcion: string;
-      porcentaje: number;
-      monto: number;
-      base: number;
-    };
+  items: FactproDocumentItemV3[];
+  condicion_de_pago: Array<{
+    tipo_de_condicion: "0" | "1";
+    forma_de_pago: "0";
+    monto: number;
+  }>;
+  totales?: {
+    monto_descuento_global: number;
   };
-  items: FactproDocumentItem[];
-  acciones: {
-    formato_pdf: "a4"; // revisar mas formatos
-  };
-  termino_de_pago: {
-    descripcion: "Contado" | "Crédito";
-    tipo: "0" | "1";
-  };
-  metodo_de_pago?: string;
-  canal_de_venta: "";
-  orden_de_compra: "";
-  observaciones: "";
-  almacen: "";
+  observaciones: string;
+  formato_pdf: "a4";
 }
 
-export interface FactproSuccessResponse {
-  success: true;
+export interface FactproSuccessResponseV3 {
+  exito: true;
+  mensaje: string | null;
   data: {
-    number: string;
-    filename: string;
-    external_id: string;
-    number_to_letter: string;
+    numero: string;
+    archivo: string;
+    letras: string;
     hash: string;
     qr: string;
+    tipo_estado?: string;
+    descripcion_estado?: string;
   };
-  links: {
+  archivos: {
     xml: string;
     pdf: string;
     cdr: string;
   };
-  response: {
-    code: string;
+  eventos?: Array<{
+    date: string;
     description: string;
-    notes: string[];
-  };
+  }>;
 }
 
-export type FactproDocumentConsult = {
-  exito: boolean; //true,
-  mensaje: string | null; //null
-  data: {
-    numero: string; //"F100-61",
-    archivo: string; //"20466590247-01-F100-61",
-    letras: string; //"Cien  con 00/100 ",
-    hash: string; //"Slhxy95DqLmoi5vxDpC7u6c89b4=",
-    qr: string; //"Nkz9Sy8AAAAASUVORK5CYII=",
-    tipo_estado: string; //"05",
-    descripcion_estado: string; //"ACEPTADO"
-  },
+export interface FactproErrorResponseV3 {
+  exito: false;
+  mensaje?: string | null;
+}
+
+export type FactproResponseV3 =
+  | FactproErrorResponseV3
+  | FactproSuccessResponseV3;
+
+export interface FactproCancelSuccessResponseV3 {
+  exito: true;
+  mensaje: string | null;
+  ticket: string;
+  hash: string;
+  fecha_de_emision: string;
+  estado_documento: string;
   archivos: {
-    pdf: string; //"https://api.factpro.la/invoice/20460590200-01-F100-61.pdf",
-    xml: string; //"https://api.factpro.la/invoice/20460590200-01-F100-61.xml",
-    cdr: string; //"https://api.factpro.la/invoice/20460590200-01-F100-61.cdr"
-  },
-  eventos: [
-    {
-      date: string; //"2025-07-11 14:08:51.151033",
-      description: string; //"El documento ha sido registrado y enviado"
-    },
-    {
-      date: string; //"2025-07-11 14:11:45.428059",
-      description: string; //"La Factura numero F100-61, ha sido aceptada"
-    }
-  ]
+    xml: string;
+    pdf: string;
+    cdr: string;
+  };
+  eventos?: Array<{
+    date: string;
+    description: string;
+  }>;
 }
 
-export interface FactproErrorResponse {
-  success: false;
-  message?: string;
-}
-
-export type FactproResponse = FactproErrorResponse | FactproSuccessResponse;
+export type FactproCancelResponseV3 =
+  | FactproErrorResponseV3
+  | FactproCancelSuccessResponseV3;

--- a/src/new-order/components/create-order-modal/payment-modal.tsx
+++ b/src/new-order/components/create-order-modal/payment-modal.tsx
@@ -28,6 +28,7 @@ import { useUserSession } from "@/lib/use-user-session";
 import DiscountFields from "@/new-order/components/create-order-modal/discount-fields";
 import { useCompany } from "@/lib/use-company";
 import useSignOut from "@/lib/use-sign-out";
+import { printOrderReceipt } from "@/printing/print-order-receipt";
 
 const PaymentViews = {
   none: NonePayment,
@@ -48,6 +49,40 @@ const allowedCompanyIdsToSeDiscount = (
 
 const companyHasDiscountFeature = (companyId: string) =>
   allowedCompanyIdsToSeDiscount.includes(companyId);
+
+const CreateOrderButton = ({
+  amountIsInvalid,
+  creatingOrder,
+  onCreateOrder,
+  paymentMode,
+}: {
+  amountIsInvalid: boolean;
+  creatingOrder: boolean;
+  onCreateOrder: () => void;
+  paymentMode: keyof typeof PaymentViews;
+}) => {
+  if (creatingOrder) {
+    return (
+      <Button className="btn-success" type="button" disabled={true}>
+        <ReloadIcon className="mr-2 h-4 w-4 animate-spin" />
+      </Button>
+    );
+  }
+
+  if (paymentMode !== "none") {
+    return (
+      <Button type="button" disabled={amountIsInvalid} onClick={onCreateOrder}>
+        Realiza pago
+      </Button>
+    );
+  }
+
+  return (
+    <Button type="button" disabled={true}>
+      Realiza pago
+    </Button>
+  );
+};
 
 const PaymentModal: React.FC<CreateOrderModalProps> = ({
   isOpen,
@@ -85,7 +120,18 @@ const PaymentModal: React.FC<CreateOrderModalProps> = ({
       });
       reset();
       onOpenChange(false);
-      window.open(`/api/orders/${response.data.order.id}/documents`, "_blank");
+      const printResult = await printOrderReceipt(response.data.order.id!);
+
+      if (printResult.success && printResult.mode === "pdf") {
+        toast({
+          description: printResult.message,
+        });
+      } else if (!printResult.success) {
+        toast({
+          variant: "destructive",
+          description: printResult.message,
+        });
+      }
     } else {
       if (response.type === "CompanyInactive") {
         toast({
@@ -106,37 +152,6 @@ const PaymentModal: React.FC<CreateOrderModalProps> = ({
     setCreatingOrder(false);
   };
 
-  const CreateOrderButton = ({
-    amountIsInvalid,
-  }: {
-    amountIsInvalid: boolean;
-    paidAmount: number;
-    total: number;
-  }) => {
-    if (creatingOrder) {
-      return (
-        <Button className="btn-success" type="button" disabled={true}>
-          <ReloadIcon className="mr-2 h-4 w-4 animate-spin" />
-        </Button>
-      );
-    } else if (paymentMode !== "none") {
-      return (
-        <Button
-          type="button"
-          disabled={amountIsInvalid}
-          onClick={handleOrderCreation}
-        >
-          Realiza pago
-        </Button>
-      );
-    } else {
-      return (
-        <Button type="button" disabled={true}>
-          Realiza pago
-        </Button>
-      );
-    }
-  };
   const handleOpenChange = (isOpen: boolean) => {
     if (!isOpen) {
       setDiscount(undefined);
@@ -168,14 +183,14 @@ const PaymentModal: React.FC<CreateOrderModalProps> = ({
           </div>
           {paymentMode !== "none" && (
             <div className="flex justify-center mt-2">
-            <Button
-              type="button"
-              variant="link"
-              onClick={resetPayment}
-              className="mt-2 md:absolute md:top-0 md:right-0 md:py-0"
-            >
-              CAMBIAR MÉTODO
-            </Button>
+              <Button
+                type="button"
+                variant="link"
+                onClick={resetPayment}
+                className="mt-2 md:absolute md:top-0 md:right-0 md:py-0"
+              >
+                CAMBIAR MÉTODO
+              </Button>
             </div>
           )}
           <PaymentView />
@@ -186,8 +201,9 @@ const PaymentModal: React.FC<CreateOrderModalProps> = ({
         <DialogFooter>
           <CreateOrderButton
             amountIsInvalid={getPaidAmount() !== order.total}
-            paidAmount={getPaidAmount()}
-            total={order.total}
+            creatingOrder={creatingOrder}
+            onCreateOrder={handleOrderCreation}
+            paymentMode={paymentMode}
           />
         </DialogFooter>
       </DialogContent>

--- a/src/order/components/order-data.tsx
+++ b/src/order/components/order-data.tsx
@@ -7,11 +7,10 @@ import {
 } from "@/shared/components/ui/card";
 import {
   formatPrice,
-  localizeDate,
   paymentMethodToText,
   shortLocalizeDate,
 } from "@/lib/utils";
-import { FileCode,Printer } from "lucide-react";
+import { FileCode } from "lucide-react";
 import { buttonVariants } from "@/shared/components/ui/button";
 import { UNIT_TYPE_MAPPER } from "@/product/constants";
 import { fullName } from "@/customer/utils";
@@ -20,15 +19,18 @@ import CancelOrderButton from "@/order/components/cancel-order-button";
 import { findBillingDocumentFor } from "@/document/db_repository";
 import { correlative } from "@/document/utils";
 import { Badge } from "@/shared/components/ui/badge";
+import OrderPrintButton from "@/order/components/order-print-button";
 
 export default async function OrderData({ order }: { order: Order }) {
   const documentResponse = await findBillingDocumentFor(order.id!);
 
-  if(!documentResponse.success) {
-    return <p>No se encontro el documento</p>
+  if (!documentResponse.success) {
+    return <p>No se encontro el documento</p>;
   }
 
-  const hasADiscount = order.orderItems.some((orderItem) => orderItem.discountAmount > 0);
+  const hasADiscount = order.orderItems.some(
+    (orderItem) => orderItem.discountAmount > 0,
+  );
 
   return (
     <div className="h-full mt-8 flex justify-center">
@@ -52,23 +54,17 @@ export default async function OrderData({ order }: { order: Order }) {
             )}
           </CardTitle>
           <div className="flex space-x-2">
-            <a
-              className={buttonVariants({variant: "ghost", size: "icon"})}
-              href={`/api/orders/${order.id}/documents`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Printer className="cursor-pointer"/>
-            </a>
-            {documentResponse.data.documentType === "invoice" || documentResponse.data.documentType === "receipt" && (
-                <a
-                  className={buttonVariants({variant: "ghost", size: "icon"})}
-                  href={`${documentResponse.data.xml}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <FileCode/>
-                </a>
+            <OrderPrintButton orderId={order.id!} />
+            {(documentResponse.data.documentType === "invoice" ||
+              documentResponse.data.documentType === "receipt") && (
+              <a
+                className={buttonVariants({ variant: "ghost", size: "icon" })}
+                href={`${documentResponse.data.xml}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <FileCode />
+              </a>
             )}
             {differenceInHours(new Date(), order.createdAt!) < 168 &&
               order.status === "completed" && (
@@ -84,10 +80,10 @@ export default async function OrderData({ order }: { order: Order }) {
         <CardContent>
           <table className="table-auto border w-full">
             <tbody>
-            <tr>
-              <td className="pl-2 border w-13 py-1 bg-slate-100 font-light w-56">
-                Cliente
-              </td>
+              <tr>
+                <td className="pl-2 border w-13 py-1 bg-slate-100 font-light w-56">
+                  Cliente
+                </td>
                 <td className="pl-2 border py-1">
                   {order.customer ? fullName(order.customer) : "-"}
                 </td>
@@ -122,72 +118,75 @@ export default async function OrderData({ order }: { order: Order }) {
           <div className="overflow-y-auto w-screen md:w-full">
             <table className="table-auto border min-w-[600px] md:w-full mt-8">
               <thead>
-              <tr>
-                <th className="bg-slate-100 pl-2 border py-1 font-light">
-                  Cantidad
-                </th>
-                <th className="bg-slate-100 pl-2 border py-1 font-light">
-                  Producto
-                </th>
-                <th className="bg-slate-100 pl-2 border py-1 font-light">
-                  Precio
-                </th>
-                {hasADiscount && (
+                <tr>
                   <th className="bg-slate-100 pl-2 border py-1 font-light">
-                    Descuento
+                    Cantidad
                   </th>
-                )}
-                <th className="bg-slate-100 pl-2 border py-1 font-light">
-                  Total
-                </th>
-              </tr>
+                  <th className="bg-slate-100 pl-2 border py-1 font-light">
+                    Producto
+                  </th>
+                  <th className="bg-slate-100 pl-2 border py-1 font-light">
+                    Precio
+                  </th>
+                  {hasADiscount && (
+                    <th className="bg-slate-100 pl-2 border py-1 font-light">
+                      Descuento
+                    </th>
+                  )}
+                  <th className="bg-slate-100 pl-2 border py-1 font-light">
+                    Total
+                  </th>
+                </tr>
               </thead>
               <tbody>
-              {order.orderItems.map((orderItem) => (
-                <tr key={orderItem.id}>
-                  <td className="pl-2 border py-1">
-                    {orderItem.quantity} {UNIT_TYPE_MAPPER[orderItem.unitType]}
-                  </td>
-                  <td className="pl-2 border py-1">{orderItem.productName}</td>
-                  <td className="pl-2 border py-1">
-                    {formatPrice(orderItem.productPrice)}
-                  </td>
-                  {hasADiscount && (
+                {order.orderItems.map((orderItem) => (
+                  <tr key={orderItem.id}>
                     <td className="pl-2 border py-1">
-                      {formatPrice(orderItem.discountAmount)}
+                      {orderItem.quantity}{" "}
+                      {UNIT_TYPE_MAPPER[orderItem.unitType]}
                     </td>
-                  )}
-                  <td className="pl-2 border py-1">
-                    {formatPrice(orderItem.total)}
-                  </td>
-                </tr>
-              ))}
+                    <td className="pl-2 border py-1">
+                      {orderItem.productName}
+                    </td>
+                    <td className="pl-2 border py-1">
+                      {formatPrice(orderItem.productPrice)}
+                    </td>
+                    {hasADiscount && (
+                      <td className="pl-2 border py-1">
+                        {formatPrice(orderItem.discountAmount)}
+                      </td>
+                    )}
+                    <td className="pl-2 border py-1">
+                      {formatPrice(orderItem.total)}
+                    </td>
+                  </tr>
+                ))}
               </tbody>
             </table>
           </div>
           <div className="w-full flex justify-between mt-8">
             <table className="table-auto border w-64">
               <thead>
-              <tr>
-                <th className="bg-slate-100 pl-2 border py-1 font-light">
-                  Método de pago
-                </th>
-                <th className="bg-slate-100 pl-2 border py-1 font-light">
-                  Monto
-                </th>
-              </tr>
+                <tr>
+                  <th className="bg-slate-100 pl-2 border py-1 font-light">
+                    Método de pago
+                  </th>
+                  <th className="bg-slate-100 pl-2 border py-1 font-light">
+                    Monto
+                  </th>
+                </tr>
               </thead>
               <tbody>
-              {order.payments.map((payment) => (
-                <tr key={payment.id}>
-                  <td className="pl-2 border py-1">
-                    {paymentMethodToText(payment.method)}
-                  </td>
-                  <td className="pl-2 border py-1">
-                    {formatPrice(payment.amount)}
-                  </td>
-                </tr>
-              ))}
+                {order.payments.map((payment) => (
+                  <tr key={payment.id}>
+                    <td className="pl-2 border py-1">
+                      {paymentMethodToText(payment.method)}
+                    </td>
+                    <td className="pl-2 border py-1">
+                      {formatPrice(payment.amount)}
+                    </td>
+                  </tr>
+                ))}
               </tbody>
             </table>
             <div className="w-56 flex flex-col">

--- a/src/order/components/order-print-button.tsx
+++ b/src/order/components/order-print-button.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Loader2, Printer } from "lucide-react";
+import { useState } from "react";
+
+import { printOrderReceipt } from "@/printing/print-order-receipt";
+import { Button } from "@/shared/components/ui/button";
+import { useToast } from "@/shared/components/ui/use-toast";
+
+export default function OrderPrintButton({ orderId }: { orderId: string }) {
+  const { toast } = useToast();
+  const [printing, setPrinting] = useState(false);
+
+  const handlePrint = async () => {
+    setPrinting(true);
+
+    try {
+      const result = await printOrderReceipt(orderId);
+
+      if (result.success && result.mode === "pdf") {
+        toast({
+          description: result.message,
+        });
+      } else if (!result.success) {
+        toast({
+          variant: "destructive",
+          description: result.message,
+        });
+      }
+    } finally {
+      setPrinting(false);
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      aria-label="Imprimir comprobante"
+      disabled={printing}
+      onClick={handlePrint}
+    >
+      {printing ? (
+        <Loader2 className="h-4 w-4 animate-spin" />
+      ) : (
+        <Printer className="cursor-pointer" />
+      )}
+    </Button>
+  );
+}

--- a/src/order/components/voucher.tsx
+++ b/src/order/components/voucher.tsx
@@ -29,6 +29,7 @@ import {
 import { Company } from "@/company/types";
 import { fullName } from "@/customer/utils";
 import { isBillableDocument } from "@/document/utils";
+import { CARNET_EXTRANJERIA, Customer, DNI, RUC } from "@/customer/types";
 
 const styles = StyleSheet.create({
   page: {
@@ -92,13 +93,24 @@ const documentTypeToEs: Record<DocumentType, string> = {
   [TICKET]: "NOTA DE VENTA ELECTRÓNICA",
 };
 
-const documentTypeToCustomerDocumentTypeES: Record<DocumentType, string> = {
-  [TICKET]: "DNI",
-  [RECEIPT]: "DNI",
-  [INVOICE]: "RUC",
+const customerDocumentTypeToES: Record<string, string> = {
+  [CARNET_EXTRANJERIA]: "Carnet de extranjería",
+  [DNI]: "DNI",
+  [RUC]: "RUC",
 };
 
 const zeroPad = (number: string) => number.padStart(8, "0");
+
+const customerDocumentTypeLabel = (
+  customer: Customer | undefined,
+  documentType: DocumentType,
+) => {
+  if (customer?.documentType) {
+    return customerDocumentTypeToES[customer.documentType];
+  }
+
+  return documentType === INVOICE ? "RUC" : "DNI";
+};
 
 const TicketTotals = ({ document }: { document: Ticket }) => (
   <View style={[styles.section, { marginTop: "10px" }]}>
@@ -320,7 +332,7 @@ const Voucher = ({ order, company, document, qrBase64 }: voucherProps) => (
         </Text>
 
         <Text style={styles.text}>
-          {documentTypeToCustomerDocumentTypeES[document.documentType]}:{" "}
+          {customerDocumentTypeLabel(order.customer, document.documentType)}:{" "}
           {order.customer?.documentNumber}
         </Text>
 

--- a/src/printing/init-printers.ts
+++ b/src/printing/init-printers.ts
@@ -1,9 +1,6 @@
 "use client";
 
-import {
-  iminSdkWrapper,
-  messageForPrintFailure,
-} from "@/printing/printers/imin/imin-sdk-wrapper";
+import { iminSdkWrapper } from "@/printing/printers/imin/imin-sdk-wrapper";
 import type {
   PrinterHealth,
   PrinterStatus,
@@ -21,17 +18,7 @@ const healthFromStatus = (status: PrinterStatus): PrinterHealth => ({
   message: status.message,
 });
 
-const unavailableHealth = (): PrinterHealth => ({
-  id: "imin",
-  status: "unavailable",
-  ready: false,
-  reason: "sdk_unavailable",
-  message: messageForPrintFailure("sdk_unavailable"),
-});
-
 const initializeImin = async (): Promise<PrinterHealth> => {
-  if (!iminSdkWrapper.isAvailable()) return unavailableHealth();
-
   const initStatus = await iminSdkWrapper.initialize();
   if (!initStatus.ready) return healthFromStatus(initStatus);
 
@@ -42,18 +29,20 @@ const initializeImin = async (): Promise<PrinterHealth> => {
 };
 
 export const initPrinters = async (): Promise<PrintersInitializationResult> => {
-  if (initializationResult) return initializationResult;
+  if (initializationResult?.printers.imin.ready) return initializationResult;
   if (initializationPromise) return initializationPromise;
 
   initializationPromise = initializeImin()
     .then((imin) => {
-      initializationResult = {
+      const result: PrintersInitializationResult = {
         initializedAt: new Date().toISOString(),
         printers: {
           imin,
         },
       };
-      return initializationResult;
+
+      if (imin.ready) initializationResult = result;
+      return result;
     })
     .finally(() => {
       initializationPromise = undefined;

--- a/src/printing/init-printers.ts
+++ b/src/printing/init-printers.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import {
+  iminSdkWrapper,
+  messageForPrintFailure,
+} from "@/printing/printers/imin/imin-sdk-wrapper";
+import type {
+  PrinterHealth,
+  PrinterStatus,
+  PrintersInitializationResult,
+} from "@/printing/types";
+
+let initializationResult: PrintersInitializationResult | undefined;
+let initializationPromise: Promise<PrintersInitializationResult> | undefined;
+
+const healthFromStatus = (status: PrinterStatus): PrinterHealth => ({
+  id: "imin",
+  status: status.ready ? "ready" : "error",
+  ready: status.ready,
+  reason: status.reason,
+  message: status.message,
+});
+
+const unavailableHealth = (): PrinterHealth => ({
+  id: "imin",
+  status: "unavailable",
+  ready: false,
+  reason: "sdk_unavailable",
+  message: messageForPrintFailure("sdk_unavailable"),
+});
+
+const initializeImin = async (): Promise<PrinterHealth> => {
+  if (!iminSdkWrapper.isAvailable()) return unavailableHealth();
+
+  const initStatus = await iminSdkWrapper.initialize();
+  if (!initStatus.ready) return healthFromStatus(initStatus);
+
+  const configStatus = await iminSdkWrapper.configure80mm();
+  if (!configStatus.ready) return healthFromStatus(configStatus);
+
+  return healthFromStatus(await iminSdkWrapper.getStatus());
+};
+
+export const initPrinters = async (): Promise<PrintersInitializationResult> => {
+  if (initializationResult) return initializationResult;
+  if (initializationPromise) return initializationPromise;
+
+  initializationPromise = initializeImin()
+    .then((imin) => {
+      initializationResult = {
+        initializedAt: new Date().toISOString(),
+        printers: {
+          imin,
+        },
+      };
+      return initializationResult;
+    })
+    .finally(() => {
+      initializationPromise = undefined;
+    });
+
+  return initializationPromise;
+};
+
+export const resetPrintersInitialization = () => {
+  initializationResult = undefined;
+  initializationPromise = undefined;
+  iminSdkWrapper.resetConnection();
+};

--- a/src/printing/print-order-receipt.ts
+++ b/src/printing/print-order-receipt.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { iminPrinter } from "@/printing/printers/imin/imin-printer";
+import type {
+  PrintFailureReason,
+  PrintResult,
+  ReceiptPrintData,
+} from "@/printing/types";
+
+type PrintDataResponse =
+  | {
+      success: true;
+      data: ReceiptPrintData;
+    }
+  | {
+      success: false;
+      message?: string;
+    };
+
+export const orderDocumentPdfUrl = (orderId: string) =>
+  `/api/orders/${orderId}/documents`;
+
+export const orderPrintDataUrl = (orderId: string) =>
+  `/api/orders/${orderId}/print-data`;
+
+const openPdfFallback = (url: string) => {
+  window.open(url, "_blank");
+};
+
+const pdfFallbackResult = (
+  reason: PrintFailureReason,
+  message = "Se abrio el comprobante en PDF.",
+): PrintResult => ({
+  success: true,
+  mode: "pdf",
+  fallbackReason: reason,
+  message,
+});
+
+export const printOrderReceipt = async (orderId: string): Promise<PrintResult> => {
+  const defaultPdfUrl = orderDocumentPdfUrl(orderId);
+
+  let receiptData: ReceiptPrintData;
+
+  try {
+    const response = await fetch(orderPrintDataUrl(orderId), {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error("Print data request failed");
+    }
+
+    const payload = (await response.json()) as PrintDataResponse;
+
+    if (!payload.success) {
+      throw new Error(payload.message ?? "Print data response failed");
+    }
+
+    receiptData = payload.data;
+  } catch {
+    openPdfFallback(defaultPdfUrl);
+    return pdfFallbackResult(
+      "data_fetch_failed",
+      "No se pudo preparar la impresion directa. Se abrio el PDF.",
+    );
+  }
+
+  const fallbackPdfUrl = receiptData.fallbackPdfUrl || defaultPdfUrl;
+
+  if (!iminPrinter.isAvailable()) {
+    openPdfFallback(fallbackPdfUrl);
+    return pdfFallbackResult(
+      "sdk_unavailable",
+      "Impresora iMin no disponible. Se abrio el PDF.",
+    );
+  }
+
+  const printResult = await iminPrinter.printReceipt(receiptData);
+
+  if (!printResult.success) {
+    openPdfFallback(fallbackPdfUrl);
+    return pdfFallbackResult(
+      printResult.reason,
+      `${printResult.message} Se abrio el PDF.`,
+    );
+  }
+
+  return printResult;
+};

--- a/src/printing/print-order-receipt.ts
+++ b/src/printing/print-order-receipt.ts
@@ -1,6 +1,11 @@
 "use client";
 
 import { iminPrinter } from "@/printing/printers/imin/imin-printer";
+import {
+  getPrintingRuntimeState,
+  isFalconPrintingEnabled,
+  waitForPrinterInitialization,
+} from "@/printing/printing-runtime";
 import type {
   PrintFailureReason,
   PrintResult,
@@ -39,6 +44,20 @@ const pdfFallbackResult = (
 
 export const printOrderReceipt = async (orderId: string): Promise<PrintResult> => {
   const defaultPdfUrl = orderDocumentPdfUrl(orderId);
+
+  if (
+    !isFalconPrintingEnabled() &&
+    !(await waitForPrinterInitialization())
+  ) {
+    const runtimeHealth = getPrintingRuntimeState().result?.printers.imin;
+    const fallbackReason = runtimeHealth?.reason ?? "sdk_unavailable";
+
+    openPdfFallback(defaultPdfUrl);
+    return pdfFallbackResult(
+      fallbackReason,
+      `${runtimeHealth?.message ?? "Impresora iMin no disponible."} Se abrio el PDF.`,
+    );
+  }
 
   let receiptData: ReceiptPrintData;
 

--- a/src/printing/printers/imin/imin-printer.ts
+++ b/src/printing/printers/imin/imin-printer.ts
@@ -10,6 +10,7 @@ import {
   iminSdkWrapper,
   messageForPrintFailure,
 } from "@/printing/printers/imin/imin-sdk-wrapper";
+import { initPrinters } from "@/printing/init-printers";
 import { buildThermalReceiptCommands } from "@/printing/printers/imin/thermal-receipt-renderer";
 
 const failedResult = (
@@ -45,6 +46,7 @@ const executeCommand = async (
         command.values,
         command.widths,
         command.aligns,
+        command.bold,
       );
     case "qr":
       return iminSdkWrapper.printQr(command.value);
@@ -58,16 +60,25 @@ const executeCommand = async (
 export const iminPrinter: PrinterAdapter = {
   isAvailable: () => iminSdkWrapper.isAvailable(),
 
+  initialize: () =>
+    initPrinters().then((result) => {
+      const health = result.printers.imin;
+      return {
+        ready: health.ready,
+        reason: health.reason,
+        message: health.message,
+      };
+    }),
+
+  getStatus: () => iminSdkWrapper.getStatus(),
+
   async printReceipt(data: ReceiptPrintData): Promise<PrintResult> {
     if (!iminSdkWrapper.isAvailable()) {
       return failedResult("sdk_unavailable");
     }
 
-    const initResult = ensureReady(await iminSdkWrapper.initialize());
+    const initResult = ensureReady(await this.initialize!());
     if (initResult) return initResult;
-
-    const configResult = ensureReady(await iminSdkWrapper.configure80mm());
-    if (configResult) return configResult;
 
     const statusResult = ensureReady(await iminSdkWrapper.getStatus());
     if (statusResult) return statusResult;
@@ -80,8 +91,16 @@ export const iminPrinter: PrinterAdapter = {
     }
 
     for (const command of commands) {
-      const commandStatus = ensureReady(await executeCommand(command));
-      if (commandStatus) return commandStatus;
+      const rawCommandStatus = await executeCommand(command);
+      const commandStatus = ensureReady(rawCommandStatus);
+      if (commandStatus) {
+        if (command.type === "cut") {
+          console.warn("iMin receipt printed, but paper cut failed", rawCommandStatus);
+          continue;
+        }
+
+        return commandStatus;
+      }
     }
 
     return {

--- a/src/printing/printers/imin/imin-printer.ts
+++ b/src/printing/printers/imin/imin-printer.ts
@@ -73,10 +73,6 @@ export const iminPrinter: PrinterAdapter = {
   getStatus: () => iminSdkWrapper.getStatus(),
 
   async printReceipt(data: ReceiptPrintData): Promise<PrintResult> {
-    if (!iminSdkWrapper.isAvailable()) {
-      return failedResult("sdk_unavailable");
-    }
-
     const initResult = ensureReady(await this.initialize!());
     if (initResult) return initResult;
 

--- a/src/printing/printers/imin/imin-printer.ts
+++ b/src/printing/printers/imin/imin-printer.ts
@@ -1,0 +1,98 @@
+import type {
+  PrintCommand,
+  PrintFailureReason,
+  PrintResult,
+  PrinterAdapter,
+  PrinterStatus,
+  ReceiptPrintData,
+} from "@/printing/types";
+import {
+  iminSdkWrapper,
+  messageForPrintFailure,
+} from "@/printing/printers/imin/imin-sdk-wrapper";
+import { buildThermalReceiptCommands } from "@/printing/printers/imin/thermal-receipt-renderer";
+
+const failedResult = (
+  reason: PrintFailureReason,
+  message = messageForPrintFailure(reason),
+): PrintResult => ({
+  success: false,
+  mode: "imin",
+  reason,
+  message,
+});
+
+const statusToResult = (status: PrinterStatus): PrintResult =>
+  failedResult(status.reason ?? "printer_unknown_error", status.message);
+
+const ensureReady = (status: PrinterStatus): PrintResult | undefined => {
+  if (status.ready) return undefined;
+  return statusToResult(status);
+};
+
+const executeCommand = async (
+  command: PrintCommand,
+): Promise<PrinterStatus> => {
+  switch (command.type) {
+    case "text":
+      return iminSdkWrapper.printText(command.value, {
+        align: command.align,
+        bold: command.bold,
+        size: command.size,
+      });
+    case "columns":
+      return iminSdkWrapper.printColumns(
+        command.values,
+        command.widths,
+        command.aligns,
+      );
+    case "qr":
+      return iminSdkWrapper.printQr(command.value);
+    case "feed":
+      return iminSdkWrapper.feed(command.lines);
+    case "cut":
+      return iminSdkWrapper.cut();
+  }
+};
+
+export const iminPrinter: PrinterAdapter = {
+  isAvailable: () => iminSdkWrapper.isAvailable(),
+
+  async printReceipt(data: ReceiptPrintData): Promise<PrintResult> {
+    if (!iminSdkWrapper.isAvailable()) {
+      return failedResult("sdk_unavailable");
+    }
+
+    const initResult = ensureReady(await iminSdkWrapper.initialize());
+    if (initResult) return initResult;
+
+    const configResult = ensureReady(await iminSdkWrapper.configure80mm());
+    if (configResult) return configResult;
+
+    const statusResult = ensureReady(await iminSdkWrapper.getStatus());
+    if (statusResult) return statusResult;
+
+    let commands: PrintCommand[];
+    try {
+      commands = buildThermalReceiptCommands(data);
+    } catch {
+      return failedResult("render_failed");
+    }
+
+    for (const command of commands) {
+      const commandStatus = ensureReady(await executeCommand(command));
+      if (commandStatus) return commandStatus;
+    }
+
+    return {
+      success: true,
+      mode: "imin",
+      message: "Comprobante impreso en iMin.",
+    };
+  },
+};
+
+export const isIminPrinterAvailable = (): boolean => iminPrinter.isAvailable();
+
+export const printReceipt = (data: ReceiptPrintData): Promise<PrintResult> =>
+  iminPrinter.printReceipt(data);

--- a/src/printing/printers/imin/imin-sdk-wrapper.ts
+++ b/src/printing/printers/imin/imin-sdk-wrapper.ts
@@ -4,14 +4,38 @@ import type {
   PrintFailureReason,
   PrinterStatus,
 } from "@/printing/types";
+import type {
+  IminMaybeAsync,
+  IminPrintCallback,
+  IminPrintInstance,
+} from "@/printing/printers/imin/types";
 
 const FALCON_80MM_PAGE_FORMAT = 0;
 const FALCON_80MM_TEXT_WIDTH = 576;
+const FALCON_QR_SIZE = 6;
+const FALCON_QR_ERROR_CORRECTION_LEVEL = 48;
+const IMIN_WEBSOCKET_URL = "ws://127.0.0.1:8081/websocket";
+const COMMAND_TIMEOUT_MS = 2_500;
+const CONNECT_TIMEOUT_MS = 1_500;
 
 type TextCommandOptions = Pick<
   Extract<PrintCommand, { type: "text" }>,
   "align" | "bold" | "size"
 >;
+
+type IminTransport = "window-sdk" | "websocket";
+
+type WebSocketConstructor = new (url: string) => WebSocket;
+
+type WebSocketResponse = {
+  id?: number;
+  result?: unknown;
+  data?: unknown;
+  status?: unknown;
+  code?: unknown;
+  error?: unknown;
+  message?: unknown;
+};
 
 const alignmentToSdkValue: Record<PrintAlignment, number> = {
   left: 0,
@@ -66,75 +90,532 @@ export const mapIminStatus = (status?: number): PrinterStatus => {
   };
 };
 
-export class IminSdkWrapper {
+const readyStatus = (message = "Comando iMin ejecutado."): PrinterStatus => ({
+  ready: true,
+  message,
+});
+
+const failedStatus = (
+  reason: PrintFailureReason,
+  message = messageForPrintFailure(reason),
+): PrinterStatus => ({
+  ready: false,
+  reason,
+  message,
+});
+
+const readWindowSdk = (): IminPrintInstance | undefined => {
+  if (typeof window === "undefined") return undefined;
+  return window.IminPrintInstance;
+};
+
+const getWebSocketConstructor = (): WebSocketConstructor | undefined => {
+  const candidate = globalThis.WebSocket;
+  return typeof candidate === "function"
+    ? (candidate as unknown as WebSocketConstructor)
+    : undefined;
+};
+
+const normalizeCallbackValue = (value: unknown): unknown => {
+  if (
+    value &&
+    typeof value === "object" &&
+    "data" in value &&
+    Object.keys(value).length === 1
+  ) {
+    return (value as { data: unknown }).data;
+  }
+
+  return value;
+};
+
+const numericFrom = (value: unknown): number | undefined => {
+  const normalized = normalizeCallbackValue(value);
+
+  if (typeof normalized === "number") return normalized;
+
+  if (typeof normalized === "string") {
+    const parsed = Number(normalized);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  if (!normalized || typeof normalized !== "object") return undefined;
+
+  const objectValue = normalized as Record<string, unknown>;
+  return (
+    numericFrom(objectValue.status) ??
+    numericFrom(objectValue.code) ??
+    numericFrom(objectValue.result) ??
+    numericFrom(objectValue.data)
+  );
+};
+
+const statusFromCommandValue = (value: unknown): PrinterStatus => {
+  const statusCode = numericFrom(value);
+  if (statusCode === undefined || statusCode === 0) return readyStatus();
+  return mapIminStatus(statusCode);
+};
+
+const sdkPromise = async <T>(
+  invoke: (callback: IminPrintCallback<T>) => IminMaybeAsync<T>,
+): Promise<T | undefined> =>
+  new Promise<T | undefined>((resolve, reject) => {
+    let settled = false;
+
+    const settle = (value: T | undefined) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+
+    const callback: IminPrintCallback<T> = (result) => {
+      settle(result);
+    };
+
+    try {
+      const returned = invoke(callback);
+
+      if (returned && typeof (returned as Promise<T>).then === "function") {
+        void (returned as Promise<T>).then(settle, reject);
+        return;
+      }
+
+      if (returned !== undefined) {
+        settle(returned as T);
+        return;
+      }
+
+      window.setTimeout(() => settle(undefined), COMMAND_TIMEOUT_MS);
+    } catch (error) {
+      reject(error);
+    }
+  });
+
+class IminWebSocketClient {
+  private socket?: WebSocket;
+  private connectPromise?: Promise<WebSocket>;
+  private nextRequestId = 1;
+  private pendingRequests = new Map<
+    number,
+    {
+      resolve: (value: unknown) => void;
+      reject: (reason?: unknown) => void;
+      timeout: ReturnType<typeof setTimeout>;
+    }
+  >();
+
+  constructor(
+    private readonly url = IMIN_WEBSOCKET_URL,
+    private readonly WebSocketImpl = getWebSocketConstructor(),
+  ) {}
+
   isAvailable(): boolean {
-    return false;
+    return Boolean(this.WebSocketImpl);
+  }
+
+  disconnect() {
+    this.pendingRequests.forEach((request) => {
+      clearTimeout(request.timeout);
+      request.reject(new Error("iMin websocket disconnected"));
+    });
+    this.pendingRequests.clear();
+
+    this.socket?.close();
+    this.socket = undefined;
+    this.connectPromise = undefined;
+  }
+
+  async command(method: string, params: unknown[] = []): Promise<unknown> {
+    const socket = await this.connect();
+    const id = this.nextRequestId++;
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pendingRequests.delete(id);
+        reject(new Error(`iMin websocket command timed out: ${method}`));
+      }, COMMAND_TIMEOUT_MS);
+
+      this.pendingRequests.set(id, { resolve, reject, timeout });
+
+      socket.send(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id,
+          method,
+          params,
+        }),
+      );
+    });
+  }
+
+  private async connect(): Promise<WebSocket> {
+    if (this.socket?.readyState === 1) return this.socket;
+    if (this.connectPromise) return this.connectPromise;
+
+    if (!this.WebSocketImpl) {
+      throw new Error("WebSocket is not available");
+    }
+
+    const WebSocketImpl = this.WebSocketImpl;
+
+    this.connectPromise = new Promise<WebSocket>((resolve, reject) => {
+      const socket = new WebSocketImpl(this.url);
+      const timeout = setTimeout(() => {
+        cleanup();
+        socket.close();
+        reject(new Error("iMin websocket connection timed out"));
+      }, CONNECT_TIMEOUT_MS);
+
+      const cleanup = () => {
+        clearTimeout(timeout);
+        socket.removeEventListener("open", handleOpen);
+        socket.removeEventListener("error", handleError);
+      };
+
+      const handleOpen = () => {
+        cleanup();
+        this.socket = socket;
+        socket.addEventListener("message", this.handleMessage);
+        socket.addEventListener("close", this.handleClose);
+        socket.addEventListener("error", this.handleClose);
+        resolve(socket);
+      };
+
+      const handleError = () => {
+        cleanup();
+        reject(new Error("iMin websocket connection failed"));
+      };
+
+      socket.addEventListener("open", handleOpen);
+      socket.addEventListener("error", handleError);
+    }).finally(() => {
+      this.connectPromise = undefined;
+    });
+
+    return this.connectPromise;
+  }
+
+  private handleClose = () => {
+    this.socket = undefined;
+    this.pendingRequests.forEach((request) => {
+      clearTimeout(request.timeout);
+      request.reject(new Error("iMin websocket connection closed"));
+    });
+    this.pendingRequests.clear();
+  };
+
+  private handleMessage = (event: MessageEvent) => {
+    const response = this.parseResponse(event.data);
+    if (!response) return;
+
+    const id = typeof response.id === "number" ? response.id : undefined;
+    if (id === undefined) return;
+
+    const request = this.pendingRequests.get(id);
+    if (!request) return;
+
+    clearTimeout(request.timeout);
+    this.pendingRequests.delete(id);
+
+    if (response.error) {
+      request.reject(response.error);
+      return;
+    }
+
+    request.resolve(response.result ?? response.data ?? response.status ?? response.code);
+  };
+
+  private parseResponse(data: unknown): WebSocketResponse | undefined {
+    if (typeof data !== "string") return undefined;
+
+    try {
+      return JSON.parse(data) as WebSocketResponse;
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+export class IminSdkWrapper {
+  private websocketClient?: IminWebSocketClient;
+  private activeTransport?: IminTransport;
+
+  isAvailable(): boolean {
+    return Boolean(readWindowSdk()) || this.getWebSocketClient().isAvailable();
   }
 
   async initialize(): Promise<PrinterStatus> {
-    return {
-      ready: false,
-      reason: "sdk_unavailable",
-      message: messageForPrintFailure("sdk_unavailable"),
-    };
+    const sdk = readWindowSdk();
+    if (sdk) {
+      return this.withWindowSdk(async () => {
+        this.requireSdkMethod(sdk, "initPrinter");
+        await sdkPromise((callback) =>
+          sdk.initPrinter?.(this.connectType(sdk), callback),
+        );
+        this.activeTransport = "window-sdk";
+        return readyStatus("Impresora iMin inicializada.");
+      });
+    }
+
+    return this.withWebSocket(async (client) => {
+      await client.command("initPrinter", [this.connectType()]);
+      this.activeTransport = "websocket";
+      return readyStatus("Impresora iMin inicializada.");
+    });
   }
 
   async configure80mm(): Promise<PrinterStatus> {
-    void FALCON_80MM_PAGE_FORMAT;
-    void FALCON_80MM_TEXT_WIDTH;
+    const sdk = readWindowSdk();
+    if (sdk) {
+      return this.withWindowSdk(async () => {
+        this.requireSdkMethod(sdk, "setPageFormat");
+        this.requireSdkMethod(sdk, "setTextWidth");
+        await sdkPromise((callback) =>
+          sdk.setPageFormat?.(FALCON_80MM_PAGE_FORMAT, callback),
+        );
+        await sdkPromise((callback) =>
+          sdk.setTextWidth?.(FALCON_80MM_TEXT_WIDTH, callback),
+        );
+        return readyStatus("Formato iMin 80mm configurado.");
+      });
+    }
 
-    return {
-      ready: false,
-      reason: "sdk_unavailable",
-      message: messageForPrintFailure("sdk_unavailable"),
-    };
+    return this.withWebSocket(async (client) => {
+      await client.command("setPageFormat", [FALCON_80MM_PAGE_FORMAT]);
+      await client.command("setTextWidth", [FALCON_80MM_TEXT_WIDTH]);
+      return readyStatus("Formato iMin 80mm configurado.");
+    });
   }
 
   async getStatus(): Promise<PrinterStatus> {
-    return {
-      ready: false,
-      reason: "sdk_unavailable",
-      message: messageForPrintFailure("sdk_unavailable"),
-    };
+    const sdk = readWindowSdk();
+    if (sdk) {
+      return this.withWindowSdk(async () => {
+        this.requireSdkMethod(sdk, "getPrinterStatus");
+        const status = await sdkPromise<number>((callback) =>
+          sdk.getPrinterStatus?.(this.connectType(sdk), callback),
+        );
+        return mapIminStatus(numericFrom(status));
+      });
+    }
+
+    return this.withWebSocket(async (client) => {
+      const status = await client.command("getPrinterStatus", [
+        this.connectType(),
+      ]);
+      return mapIminStatus(numericFrom(status));
+    });
   }
 
   async printText(
-    _value: string,
-    _options?: TextCommandOptions,
+    value: string,
+    options?: TextCommandOptions,
   ): Promise<PrinterStatus> {
-    return this.unavailable();
+    const sdk = readWindowSdk();
+    if (sdk) {
+      return this.withWindowSdk(async () => {
+        await this.configureText(sdk, options);
+        this.requireSdkMethod(sdk, "printText");
+        const result = await sdkPromise((callback) =>
+          sdk.printText?.(`${value}\n`, callback),
+        );
+        return statusFromCommandValue(result);
+      });
+    }
+
+    return this.withWebSocket(async (client) => {
+      await client.command("setAlignment", [
+        this.sdkAlignmentFor(options?.align),
+      ]);
+      await client.command("setTextSize", [options?.size ?? 1]);
+      await client.command("setTextStyle", [options?.bold ? 1 : 0]);
+      return statusFromCommandValue(
+        await client.command("printText", [`${value}\n`]),
+      );
+    });
   }
 
   async printColumns(
-    _values: string[],
-    _widths: number[],
-    _aligns: PrintAlignment[],
+    values: string[],
+    widths: number[],
+    aligns: PrintAlignment[],
+    bold = false,
   ): Promise<PrinterStatus> {
-    return this.unavailable();
+    const sdkAligns = aligns.map((align) => this.sdkAlignmentFor(align));
+    const sdk = readWindowSdk();
+    if (sdk) {
+      return this.withWindowSdk(async () => {
+        this.requireSdkMethod(sdk, "setTextStyle");
+        this.requireSdkMethod(sdk, "printColumnsText");
+        await sdkPromise((callback) => sdk.setTextStyle?.(bold ? 1 : 0, callback));
+        const result = await sdkPromise((callback) =>
+          sdk.printColumnsText?.(values, widths, sdkAligns, callback),
+        );
+        return statusFromCommandValue(result);
+      });
+    }
+
+    return this.withWebSocket(async (client) => {
+      await client.command("setTextStyle", [bold ? 1 : 0]);
+      return statusFromCommandValue(
+        await client.command("printColumnsText", [values, widths, sdkAligns]),
+      );
+    });
   }
 
-  async printQr(_value: string): Promise<PrinterStatus> {
-    return this.unavailable();
+  async printQr(value: string): Promise<PrinterStatus> {
+    const sdk = readWindowSdk();
+    if (sdk) {
+      return this.withWindowSdk(async () => {
+        this.requireSdkMethod(sdk, "printQrCode");
+        if (sdk.setQrCodeSize) {
+          await sdkPromise((callback) =>
+            sdk.setQrCodeSize?.(FALCON_QR_SIZE, callback),
+          );
+        }
+        if (sdk.setQrCodeErrorCorrectionLev) {
+          await sdkPromise((callback) =>
+            sdk.setQrCodeErrorCorrectionLev?.(
+              FALCON_QR_ERROR_CORRECTION_LEVEL,
+              callback,
+            ),
+          );
+        }
+        const result = await sdkPromise((callback) =>
+          sdk.printQrCode?.(value, callback),
+        );
+        return statusFromCommandValue(result);
+      });
+    }
+
+    return this.withWebSocket(async (client) => {
+      await client.command("setQrCodeSize", [FALCON_QR_SIZE]);
+      await client.command("setQrCodeErrorCorrectionLev", [
+        FALCON_QR_ERROR_CORRECTION_LEVEL,
+      ]);
+      return statusFromCommandValue(await client.command("printQrCode", [value]));
+    });
   }
 
-  async feed(_lines: number): Promise<PrinterStatus> {
-    return this.unavailable();
+  async feed(lines: number): Promise<PrinterStatus> {
+    const sdk = readWindowSdk();
+    if (sdk) {
+      return this.withWindowSdk(async () => {
+        if (sdk.printAndFeedPaper) {
+          return statusFromCommandValue(
+            await sdkPromise((callback) =>
+              sdk.printAndFeedPaper?.(lines, callback),
+            ),
+          );
+        }
+
+        this.requireSdkMethod(sdk, "printAndLineFeed");
+        for (let index = 0; index < lines; index += 1) {
+          const result = await sdkPromise((callback) =>
+            sdk.printAndLineFeed?.(callback),
+          );
+          const status = statusFromCommandValue(result);
+          if (!status.ready) return status;
+        }
+        return readyStatus();
+      });
+    }
+
+    return this.withWebSocket(async (client) =>
+      statusFromCommandValue(await client.command("printAndFeedPaper", [lines])),
+    );
   }
 
   async cut(): Promise<PrinterStatus> {
-    return this.unavailable();
+    const sdk = readWindowSdk();
+    if (sdk) {
+      return this.withWindowSdk(async () => {
+        const cutMethod = sdk.partialCut ?? sdk.partialCutPaper;
+        if (!cutMethod) return failedStatus("plugin_unavailable");
+        const result = await sdkPromise((callback) => cutMethod.call(sdk, callback));
+        return statusFromCommandValue(result);
+      });
+    }
+
+    return this.withWebSocket(async (client) =>
+      statusFromCommandValue(await client.command("partialCut", [])),
+    );
+  }
+
+  resetConnection() {
+    this.websocketClient?.disconnect();
+    this.websocketClient = undefined;
+    this.activeTransport = undefined;
   }
 
   sdkAlignmentFor(align: PrintAlignment = "left"): number {
     return alignmentToSdkValue[align];
   }
 
-  private unavailable(): PrinterStatus {
-    return {
-      ready: false,
-      reason: "sdk_unavailable",
-      message: messageForPrintFailure("sdk_unavailable"),
-    };
+  getActiveTransport(): IminTransport | undefined {
+    return this.activeTransport;
+  }
+
+  private getWebSocketClient(): IminWebSocketClient {
+    this.websocketClient ??= new IminWebSocketClient();
+    return this.websocketClient;
+  }
+
+  private connectType(sdk?: IminPrintInstance): string | number {
+    return sdk?.PrintConnectType?.USB ?? "USB";
+  }
+
+  private async configureText(
+    sdk: IminPrintInstance,
+    options: TextCommandOptions | undefined,
+  ) {
+    this.requireSdkMethod(sdk, "setAlignment");
+    this.requireSdkMethod(sdk, "setTextSize");
+    this.requireSdkMethod(sdk, "setTextStyle");
+
+    await sdkPromise((callback) =>
+      sdk.setAlignment?.(this.sdkAlignmentFor(options?.align), callback),
+    );
+    await sdkPromise((callback) =>
+      sdk.setTextSize?.(options?.size ?? 1, callback),
+    );
+    await sdkPromise((callback) =>
+      sdk.setTextStyle?.(options?.bold ? 1 : 0, callback),
+    );
+  }
+
+  private requireSdkMethod<K extends keyof IminPrintInstance>(
+    sdk: IminPrintInstance,
+    method: K,
+  ) {
+    if (typeof sdk[method] !== "function") {
+      throw new Error(`iMin SDK method is unavailable: ${String(method)}`);
+    }
+  }
+
+  private async withWindowSdk(
+    action: () => Promise<PrinterStatus>,
+  ): Promise<PrinterStatus> {
+    try {
+      return await action();
+    } catch (error) {
+      console.warn("iMin window SDK command failed", error);
+      return failedStatus("plugin_unavailable");
+    }
+  }
+
+  private async withWebSocket(
+    action: (client: IminWebSocketClient) => Promise<PrinterStatus>,
+  ): Promise<PrinterStatus> {
+    const client = this.getWebSocketClient();
+    if (!client.isAvailable()) return failedStatus("sdk_unavailable");
+
+    try {
+      return await action(client);
+    } catch (error) {
+      console.warn("iMin websocket command failed", error);
+      return failedStatus("plugin_unavailable");
+    }
   }
 }
 

--- a/src/printing/printers/imin/imin-sdk-wrapper.ts
+++ b/src/printing/printers/imin/imin-sdk-wrapper.ts
@@ -1,0 +1,141 @@
+import type {
+  PrintAlignment,
+  PrintCommand,
+  PrintFailureReason,
+  PrinterStatus,
+} from "@/printing/types";
+
+const FALCON_80MM_PAGE_FORMAT = 0;
+const FALCON_80MM_TEXT_WIDTH = 576;
+
+type TextCommandOptions = Pick<
+  Extract<PrintCommand, { type: "text" }>,
+  "align" | "bold" | "size"
+>;
+
+const alignmentToSdkValue: Record<PrintAlignment, number> = {
+  left: 0,
+  center: 1,
+  right: 2,
+};
+
+const printerStatusReason: Record<number, PrintFailureReason> = {
+  [-1]: "printer_not_connected",
+  1: "printer_not_connected",
+  3: "printer_head_open",
+  7: "paper_out",
+  8: "paper_low",
+  99: "printer_unknown_error",
+};
+
+const printerStatusMessage: Record<PrintFailureReason, string> = {
+  sdk_unavailable: "El SDK de iMin no esta disponible en este navegador.",
+  plugin_unavailable: "El plugin de impresion iMin no esta disponible.",
+  printer_not_connected: "La impresora iMin no esta conectada.",
+  printer_head_open: "La tapa de la impresora iMin esta abierta.",
+  paper_out: "La impresora iMin no tiene papel.",
+  paper_low: "La impresora iMin tiene poco papel.",
+  printer_unknown_error: "La impresora iMin reporto un error desconocido.",
+  data_fetch_failed: "No se pudo obtener la informacion para imprimir.",
+  render_failed: "No se pudo preparar el comprobante para impresion termica.",
+  print_failed: "No se pudo imprimir el comprobante en la impresora iMin.",
+};
+
+export const messageForPrintFailure = (reason: PrintFailureReason): string =>
+  printerStatusMessage[reason];
+
+export const mapIminStatus = (status?: number): PrinterStatus => {
+  if (status === 0) {
+    return {
+      code: status,
+      ready: true,
+      message: "La impresora iMin esta lista.",
+    };
+  }
+
+  const reason =
+    typeof status === "number"
+      ? printerStatusReason[status] ?? "printer_unknown_error"
+      : "printer_unknown_error";
+
+  return {
+    code: status,
+    ready: false,
+    reason,
+    message: messageForPrintFailure(reason),
+  };
+};
+
+export class IminSdkWrapper {
+  isAvailable(): boolean {
+    return false;
+  }
+
+  async initialize(): Promise<PrinterStatus> {
+    return {
+      ready: false,
+      reason: "sdk_unavailable",
+      message: messageForPrintFailure("sdk_unavailable"),
+    };
+  }
+
+  async configure80mm(): Promise<PrinterStatus> {
+    void FALCON_80MM_PAGE_FORMAT;
+    void FALCON_80MM_TEXT_WIDTH;
+
+    return {
+      ready: false,
+      reason: "sdk_unavailable",
+      message: messageForPrintFailure("sdk_unavailable"),
+    };
+  }
+
+  async getStatus(): Promise<PrinterStatus> {
+    return {
+      ready: false,
+      reason: "sdk_unavailable",
+      message: messageForPrintFailure("sdk_unavailable"),
+    };
+  }
+
+  async printText(
+    _value: string,
+    _options?: TextCommandOptions,
+  ): Promise<PrinterStatus> {
+    return this.unavailable();
+  }
+
+  async printColumns(
+    _values: string[],
+    _widths: number[],
+    _aligns: PrintAlignment[],
+  ): Promise<PrinterStatus> {
+    return this.unavailable();
+  }
+
+  async printQr(_value: string): Promise<PrinterStatus> {
+    return this.unavailable();
+  }
+
+  async feed(_lines: number): Promise<PrinterStatus> {
+    return this.unavailable();
+  }
+
+  async cut(): Promise<PrinterStatus> {
+    return this.unavailable();
+  }
+
+  sdkAlignmentFor(align: PrintAlignment = "left"): number {
+    return alignmentToSdkValue[align];
+  }
+
+  private unavailable(): PrinterStatus {
+    return {
+      ready: false,
+      reason: "sdk_unavailable",
+      message: messageForPrintFailure("sdk_unavailable"),
+    };
+  }
+}
+
+export const iminSdkWrapper = new IminSdkWrapper();

--- a/src/printing/printers/imin/imin-sdk-wrapper.ts
+++ b/src/printing/printers/imin/imin-sdk-wrapper.ts
@@ -17,6 +17,7 @@ const FALCON_QR_ERROR_CORRECTION_LEVEL = 48;
 const IMIN_WEBSOCKET_URL = "ws://127.0.0.1:8081/websocket";
 const COMMAND_TIMEOUT_MS = 2_500;
 const CONNECT_TIMEOUT_MS = 1_500;
+const IMIN_WEBSOCKET_CONTRACT_LOG_PREFIX = "[iMin WebSocket contract]";
 
 type TextCommandOptions = Pick<
   Extract<PrintCommand, { type: "text" }>,
@@ -33,6 +34,7 @@ type WebSocketResponse = {
   data?: unknown;
   status?: unknown;
   code?: unknown;
+  value?: unknown;
   error?: unknown;
   message?: unknown;
 };
@@ -143,6 +145,7 @@ const numericFrom = (value: unknown): number | undefined => {
 
   const objectValue = normalized as Record<string, unknown>;
   return (
+    numericFrom(objectValue.value) ??
     numericFrom(objectValue.status) ??
     numericFrom(objectValue.code) ??
     numericFrom(objectValue.result) ??
@@ -152,7 +155,27 @@ const numericFrom = (value: unknown): number | undefined => {
 
 const statusFromCommandValue = (value: unknown): PrinterStatus => {
   const statusCode = numericFrom(value);
-  if (statusCode === undefined || statusCode === 0) return readyStatus();
+  if (statusCode === undefined) {
+    if (value !== undefined) {
+      console.warn(
+        `${IMIN_WEBSOCKET_CONTRACT_LOG_PREFIX} Command response did not include a numeric status code.`,
+        {
+          response: value,
+          expectedShapes: [
+            0,
+            { value: 0 },
+            { result: { value: 0 } },
+            { data: { value: 0 } },
+            { status: { value: 0 } },
+          ],
+        },
+      );
+    }
+
+    return readyStatus();
+  }
+
+  if (statusCode === 0) return readyStatus();
   return mapIminStatus(statusCode);
 };
 
@@ -201,6 +224,8 @@ class IminWebSocketClient {
       resolve: (value: unknown) => void;
       reject: (reason?: unknown) => void;
       timeout: ReturnType<typeof setTimeout>;
+      method: string;
+      params: unknown[];
     }
   >();
 
@@ -228,23 +253,34 @@ class IminWebSocketClient {
   async command(method: string, params: unknown[] = []): Promise<unknown> {
     const socket = await this.connect();
     const id = this.nextRequestId++;
+    const payload = {
+      jsonrpc: "2.0",
+      id,
+      method,
+      params,
+    };
 
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.pendingRequests.delete(id);
+        console.warn(
+          `${IMIN_WEBSOCKET_CONTRACT_LOG_PREFIX} Command timed out waiting for a response with matching id.`,
+          {
+            request: payload,
+            expectedResponseShapes: [
+              { id, result: { value: 0 } },
+              { id, data: { value: 0 } },
+              { id, status: { value: 0 } },
+              { id, value: 0 },
+            ],
+          },
+        );
         reject(new Error(`iMin websocket command timed out: ${method}`));
       }, COMMAND_TIMEOUT_MS);
 
-      this.pendingRequests.set(id, { resolve, reject, timeout });
+      this.pendingRequests.set(id, { resolve, reject, timeout, method, params });
 
-      socket.send(
-        JSON.stringify({
-          jsonrpc: "2.0",
-          id,
-          method,
-          params,
-        }),
-      );
+      socket.send(JSON.stringify(payload));
     });
   }
 
@@ -306,23 +342,69 @@ class IminWebSocketClient {
 
   private handleMessage = (event: MessageEvent) => {
     const response = this.parseResponse(event.data);
-    if (!response) return;
+    if (!response) {
+      console.warn(
+        `${IMIN_WEBSOCKET_CONTRACT_LOG_PREFIX} Received a non-JSON or unsupported response.`,
+        {
+          rawResponse: event.data,
+        },
+      );
+      return;
+    }
 
     const id = typeof response.id === "number" ? response.id : undefined;
-    if (id === undefined) return;
+    if (id === undefined) {
+      console.warn(
+        `${IMIN_WEBSOCKET_CONTRACT_LOG_PREFIX} Received a response without numeric id.`,
+        {
+          response,
+          pendingRequests: Array.from(this.pendingRequests.values()).map(
+            ({ method, params }) => ({ method, params }),
+          ),
+        },
+      );
+      return;
+    }
 
     const request = this.pendingRequests.get(id);
-    if (!request) return;
+    if (!request) {
+      console.warn(
+        `${IMIN_WEBSOCKET_CONTRACT_LOG_PREFIX} Received a response for an unknown id.`,
+        {
+          response,
+          pendingRequestIds: Array.from(this.pendingRequests.keys()),
+        },
+      );
+      return;
+    }
 
     clearTimeout(request.timeout);
     this.pendingRequests.delete(id);
 
     if (response.error) {
+      console.warn(
+        `${IMIN_WEBSOCKET_CONTRACT_LOG_PREFIX} Service returned an error response.`,
+        {
+          request: {
+            id,
+            method: request.method,
+            params: request.params,
+          },
+          response,
+        },
+      );
       request.reject(response.error);
       return;
     }
 
-    request.resolve(response.result ?? response.data ?? response.status ?? response.code);
+    request.resolve(
+      response.result ??
+        response.data ??
+        response.status ??
+        response.code ??
+        response.value ??
+        response,
+    );
   };
 
   private parseResponse(data: unknown): WebSocketResponse | undefined {
@@ -341,7 +423,7 @@ export class IminSdkWrapper {
   private activeTransport?: IminTransport;
 
   isAvailable(): boolean {
-    return Boolean(readWindowSdk()) || this.getWebSocketClient().isAvailable();
+    return Boolean(readWindowSdk()) || this.activeTransport === "websocket";
   }
 
   async initialize(): Promise<PrinterStatus> {
@@ -458,7 +540,13 @@ export class IminSdkWrapper {
     return this.withWebSocket(async (client) => {
       await client.command("setTextStyle", [bold ? 1 : 0]);
       return statusFromCommandValue(
-        await client.command("printColumnsText", [values, widths, sdkAligns]),
+        await client.command("printColumnsText", [
+          values,
+          widths,
+          sdkAligns,
+          FALCON_80MM_TEXT_WIDTH,
+          1,
+        ]),
       );
     });
   }

--- a/src/printing/printers/imin/thermal-receipt-renderer.ts
+++ b/src/printing/printers/imin/thermal-receipt-renderer.ts
@@ -1,0 +1,316 @@
+import { INVOICE, RECEIPT, TICKET, type DocumentType } from "@/document/types";
+import {
+  billableNumberToWords,
+  formatPriceWithoutCurrency,
+  paymentMethodToText,
+  shortLocalizeDate,
+} from "@/lib/utils";
+import type {
+  PrintAlignment,
+  PrintCommand,
+  ReceiptPrintData,
+} from "@/printing/types";
+import { UNIT_TYPE_MAPPER } from "@/product/constants";
+
+const COLUMNS = 48;
+const ITEM_NAME_WIDTH = 24;
+
+const documentTypeToText: Record<DocumentType, string> = {
+  [INVOICE]: "FACTURA ELECTRONICA",
+  [RECEIPT]: "BOLETA ELECTRONICA",
+  [TICKET]: "NOTA DE VENTA ELECTRONICA",
+};
+
+const customerDocumentTypeToText: Record<string, string> = {
+  dni: "DNI",
+  ruc: "RUC",
+  carnet_extranjeria: "Carnet de extranjeria",
+};
+
+const text = (
+  value: string,
+  options: Omit<Extract<PrintCommand, { type: "text" }>, "type" | "value"> = {},
+): PrintCommand => ({
+  type: "text",
+  value,
+  ...options,
+});
+
+const columns = (
+  values: string[],
+  widths: number[],
+  aligns: PrintAlignment[],
+  bold?: boolean,
+): PrintCommand => ({
+  type: "columns",
+  values,
+  widths,
+  aligns,
+  bold,
+});
+
+const separator = (char = "-") => text(char.repeat(COLUMNS));
+
+const clean = (value: string | number | undefined | null): string =>
+  String(value ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const money = (value: number): string => formatPriceWithoutCurrency(value);
+
+const formatDate = (value: string): string => shortLocalizeDate(new Date(value));
+
+const chunkText = (value: string, width: number): string[] => {
+  const words = clean(value).split(" ").filter(Boolean);
+  const lines: string[] = [];
+  let current = "";
+
+  words.forEach((word) => {
+    if (!current) {
+      current = word;
+      return;
+    }
+
+    if (`${current} ${word}`.length <= width) {
+      current = `${current} ${word}`;
+      return;
+    }
+
+    lines.push(current);
+    current = word;
+  });
+
+  if (current) {
+    lines.push(current);
+  }
+
+  return lines.flatMap((line) => {
+    if (line.length <= width) return [line];
+
+    const chunks: string[] = [];
+    for (let index = 0; index < line.length; index += width) {
+      chunks.push(line.slice(index, index + width));
+    }
+    return chunks;
+  });
+};
+
+const pushWrappedLabel = (
+  commands: PrintCommand[],
+  label: string,
+  value: string | undefined,
+) => {
+  if (!value) return;
+
+  chunkText(`${label}: ${value}`, COLUMNS).forEach((line) => {
+    commands.push(text(line));
+  });
+};
+
+const addHeader = (commands: PrintCommand[], data: ReceiptPrintData) => {
+  const { company, document } = data;
+
+  commands.push(text(clean(company.commercialName || company.legalName), {
+    align: "center",
+    bold: true,
+    size: 2,
+  }));
+
+  if (company.legalName && company.legalName !== company.commercialName) {
+    commands.push(text(clean(company.legalName), { align: "center" }));
+  }
+
+  pushWrappedLabel(commands, "RUC", company.ruc);
+  pushWrappedLabel(commands, "Direccion", company.address);
+  pushWrappedLabel(commands, "Ubicacion", company.location);
+  pushWrappedLabel(commands, "Email", company.email);
+  pushWrappedLabel(commands, "Telefono", company.phone);
+
+  commands.push(separator("="));
+  commands.push(text(documentTypeToText[document.type], {
+    align: "center",
+    bold: true,
+  }));
+  commands.push(text(document.correlative, { align: "center", bold: true }));
+  commands.push(separator("="));
+};
+
+const addDocumentData = (commands: PrintCommand[], data: ReceiptPrintData) => {
+  const { customer, document, order } = data;
+  const customerDocumentLabel = customer?.documentType
+    ? customerDocumentTypeToText[customer.documentType] ?? customer.documentType
+    : document.type === INVOICE
+      ? "RUC"
+      : "DNI";
+
+  pushWrappedLabel(commands, "F. Emision", formatDate(document.dateOfIssue));
+
+  if (document.issuedAt) {
+    pushWrappedLabel(commands, "F. Envio", formatDate(document.issuedAt));
+  }
+
+  pushWrappedLabel(commands, "Pedido", order.id);
+  pushWrappedLabel(commands, "Cliente", customer?.name || "Cliente varios");
+  pushWrappedLabel(commands, customerDocumentLabel, customer?.documentNumber);
+  pushWrappedLabel(commands, "Direccion", customer?.address);
+  pushWrappedLabel(commands, "Email", customer?.email);
+  pushWrappedLabel(commands, "Telefono", customer?.phone);
+
+  if (document.status === "cancelled") {
+    commands.push(text("DOCUMENTO ANULADO", { align: "center", bold: true }));
+    pushWrappedLabel(commands, "Motivo", document.cancellationReason);
+  }
+};
+
+const addItems = (commands: PrintCommand[], data: ReceiptPrintData) => {
+  commands.push(separator());
+  commands.push(
+    columns(
+      ["Cant", "Producto", "P.Unit", "Total"],
+      [6, 24, 8, 10],
+      ["left", "left", "right", "right"],
+      true,
+    ),
+  );
+  commands.push(separator());
+
+  data.order.items.forEach((item) => {
+    const quantity = `${item.quantity} ${UNIT_TYPE_MAPPER[item.unitType]}`;
+    const productLines = chunkText(item.name, ITEM_NAME_WIDTH);
+    const [firstLine = ""] = productLines;
+
+    commands.push(
+      columns(
+        [quantity, firstLine, money(item.unitPrice), money(item.netTotal)],
+        [6, 24, 8, 10],
+        ["left", "left", "right", "right"],
+      ),
+    );
+
+    productLines.slice(1).forEach((line) => {
+      commands.push(
+        columns(
+          ["", line, "", ""],
+          [6, 24, 8, 10],
+          ["left", "left", "right", "right"],
+        ),
+      );
+    });
+
+    if (item.discountAmount > 0) {
+      commands.push(
+        columns(
+          ["", "Descuento", "", `-${money(item.discountAmount)}`],
+          [6, 24, 8, 10],
+          ["left", "left", "right", "right"],
+        ),
+      );
+    }
+  });
+};
+
+const addTotals = (commands: PrintCommand[], data: ReceiptPrintData) => {
+  commands.push(separator());
+
+  if (data.order.discount > 0) {
+    commands.push(
+      columns(
+        ["Subtotal", money(data.order.subtotal)],
+        [34, 14],
+        ["right", "right"],
+      ),
+    );
+    commands.push(
+      columns(
+        ["Descuento", `-${money(data.order.discount)}`],
+        [34, 14],
+        ["right", "right"],
+      ),
+    );
+  }
+
+  commands.push(
+    columns(
+      ["TOTAL S/", money(data.order.total)],
+      [34, 14],
+      ["right", "right"],
+      true,
+    ),
+  );
+
+  chunkText(`Son: ${billableNumberToWords(data.order.total)}`, COLUMNS).forEach(
+    (line) => commands.push(text(line)),
+  );
+};
+
+const addPayments = (commands: PrintCommand[], data: ReceiptPrintData) => {
+  if (!data.order.payments.length) return;
+
+  commands.push(separator());
+  commands.push(text("Pagos", { bold: true }));
+
+  data.order.payments.forEach((payment) => {
+    const label =
+      payment.method === "wallet" && payment.walletName
+        ? `${paymentMethodToText(payment.method)} ${payment.walletName}`
+        : paymentMethodToText(payment.method);
+
+    commands.push(
+      columns([label, money(payment.amount)], [34, 14], ["left", "right"]),
+    );
+
+    pushWrappedLabel(commands, "Operacion", payment.operationCode);
+
+    if (payment.receivedAmount !== undefined) {
+      commands.push(
+        columns(
+          ["Recibido", money(payment.receivedAmount)],
+          [34, 14],
+          ["left", "right"],
+        ),
+      );
+    }
+
+    if (payment.change !== undefined && payment.change > 0) {
+      commands.push(
+        columns(["Vuelto", money(payment.change)], [34, 14], [
+          "left",
+          "right",
+        ]),
+      );
+    }
+  });
+};
+
+const addFooter = (commands: PrintCommand[], data: ReceiptPrintData) => {
+  if (data.document.hash) {
+    commands.push(separator());
+    commands.push(text("Codigo hash:", { bold: true }));
+    chunkText(data.document.hash, COLUMNS).forEach((line) => {
+      commands.push(text(line));
+    });
+  }
+
+  if (data.document.qr) {
+    commands.push({ type: "qr", value: data.document.qr });
+  }
+
+  commands.push(text("Gracias por su compra", { align: "center" }));
+  commands.push({ type: "feed", lines: 4 });
+  commands.push({ type: "cut" });
+};
+
+export const buildThermalReceiptCommands = (
+  data: ReceiptPrintData,
+): PrintCommand[] => {
+  const commands: PrintCommand[] = [];
+
+  addHeader(commands, data);
+  addDocumentData(commands, data);
+  addItems(commands, data);
+  addTotals(commands, data);
+  addPayments(commands, data);
+  addFooter(commands, data);
+
+  return commands;
+};

--- a/src/printing/printers/imin/types.ts
+++ b/src/printing/printers/imin/types.ts
@@ -1,0 +1,76 @@
+export type IminPrintConnectType = {
+  USB?: string | number;
+  BLUETOOTH?: string | number;
+  SPI?: string | number;
+  SERIAL?: string | number;
+};
+
+export type IminPrintCallback<T = unknown> = (result: T) => void;
+
+export type IminMaybeAsync<T = unknown> = Promise<T> | T | void;
+
+export type IminPrintInstance = {
+  PrintConnectType?: IminPrintConnectType;
+  initPrinter?: (
+    connectType?: string | number,
+    callback?: IminPrintCallback,
+  ) => IminMaybeAsync;
+  getPrinterStatus?: (
+    connectType?: string | number,
+    callback?: IminPrintCallback<number>,
+  ) => IminMaybeAsync<number>;
+  setPageFormat?: (
+    format: number,
+    callback?: IminPrintCallback,
+  ) => IminMaybeAsync;
+  setTextWidth?: (
+    width: number,
+    callback?: IminPrintCallback,
+  ) => IminMaybeAsync;
+  setAlignment?: (
+    alignment: number,
+    callback?: IminPrintCallback,
+  ) => IminMaybeAsync;
+  setTextSize?: (
+    size: number,
+    callback?: IminPrintCallback,
+  ) => IminMaybeAsync;
+  setTextStyle?: (
+    style: number,
+    callback?: IminPrintCallback,
+  ) => IminMaybeAsync;
+  printText?: (text: string, callback?: IminPrintCallback) => IminMaybeAsync;
+  printColumnsText?: (
+    values: string[],
+    widths: number[],
+    aligns: number[],
+    callback?: IminPrintCallback,
+  ) => IminMaybeAsync;
+  setQrCodeSize?: (
+    size: number,
+    callback?: IminPrintCallback,
+  ) => IminMaybeAsync;
+  setQrCodeErrorCorrectionLev?: (
+    level: number,
+    callback?: IminPrintCallback,
+  ) => IminMaybeAsync;
+  printQrCode?: (
+    value: string,
+    callback?: IminPrintCallback,
+  ) => IminMaybeAsync;
+  printAndLineFeed?: (callback?: IminPrintCallback) => IminMaybeAsync;
+  printAndFeedPaper?: (
+    lines: number,
+    callback?: IminPrintCallback,
+  ) => IminMaybeAsync;
+  partialCut?: (callback?: IminPrintCallback) => IminMaybeAsync;
+  partialCutPaper?: (callback?: IminPrintCallback) => IminMaybeAsync;
+};
+
+declare global {
+  interface Window {
+    IminPrintInstance?: IminPrintInstance;
+  }
+}
+
+export {};

--- a/src/printing/printers/imin/types.ts
+++ b/src/printing/printers/imin/types.ts
@@ -9,6 +9,23 @@ export type IminPrintCallback<T = unknown> = (result: T) => void;
 
 export type IminMaybeAsync<T = unknown> = Promise<T> | T | void;
 
+export type IminPrintColumnsText = {
+  (
+    values: string[],
+    widths: number[],
+    aligns: number[],
+    callback?: IminPrintCallback,
+  ): IminMaybeAsync;
+  (
+    values: string[],
+    widths: number[],
+    aligns: number[],
+    width: number,
+    size: number,
+    callback?: IminPrintCallback,
+  ): IminMaybeAsync;
+};
+
 export type IminPrintInstance = {
   PrintConnectType?: IminPrintConnectType;
   initPrinter?: (
@@ -40,12 +57,7 @@ export type IminPrintInstance = {
     callback?: IminPrintCallback,
   ) => IminMaybeAsync;
   printText?: (text: string, callback?: IminPrintCallback) => IminMaybeAsync;
-  printColumnsText?: (
-    values: string[],
-    widths: number[],
-    aligns: number[],
-    callback?: IminPrintCallback,
-  ) => IminMaybeAsync;
+  printColumnsText?: IminPrintColumnsText;
   setQrCodeSize?: (
     size: number,
     callback?: IminPrintCallback,

--- a/src/printing/printing-provider.tsx
+++ b/src/printing/printing-provider.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+
+import { initializePrintingRuntime } from "@/printing/printing-runtime";
+
+export function PrintingProvider({ children }: { children: ReactNode }) {
+  useEffect(() => {
+    void initializePrintingRuntime().catch((error) => {
+      console.warn("Printing runtime initialization failed", error);
+    });
+  }, []);
+
+  return children;
+}

--- a/src/printing/printing-runtime.ts
+++ b/src/printing/printing-runtime.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { initPrinters } from "@/printing/init-printers";
+import type { PrintersInitializationResult } from "@/printing/types";
+
+export type PrintingRuntimeStatus = "initializing" | "ready" | "disabled";
+
+type PrintingRuntimeState = {
+  status: PrintingRuntimeStatus;
+  result?: PrintersInitializationResult;
+};
+
+let runtimeState: PrintingRuntimeState = {
+  status: "initializing",
+};
+let runtimePromise: Promise<PrintersInitializationResult> | undefined;
+
+const statusFromResult = (
+  result: PrintersInitializationResult,
+): PrintingRuntimeStatus => (result.printers.imin.ready ? "ready" : "disabled");
+
+export const initializePrintingRuntime =
+  async (): Promise<PrintersInitializationResult> => {
+    if (runtimeState.result) return runtimeState.result;
+    if (runtimePromise) return runtimePromise;
+
+    runtimeState = {
+      ...runtimeState,
+      status: "initializing",
+    };
+
+    runtimePromise = initPrinters()
+      .then((result) => {
+        runtimeState = {
+          status: statusFromResult(result),
+          result,
+        };
+        return result;
+      })
+      .catch(() => {
+        const result: PrintersInitializationResult = {
+          initializedAt: new Date().toISOString(),
+          printers: {
+            imin: {
+              id: "imin",
+              status: "unavailable",
+              ready: false,
+              reason: "plugin_unavailable",
+              message: "No se pudo inicializar la impresora iMin.",
+            },
+          },
+        };
+
+        runtimeState = {
+          status: "disabled",
+          result,
+        };
+        return result;
+      })
+      .finally(() => {
+        runtimePromise = undefined;
+      });
+
+    return runtimePromise;
+  };
+
+export const isFalconPrintingEnabled = (): boolean =>
+  runtimeState.status === "ready";
+
+export const waitForPrinterInitialization = async (): Promise<boolean> => {
+  if (runtimeState.status === "ready") return true;
+  if (runtimeState.status === "disabled") return false;
+
+  try {
+    const result = await initializePrintingRuntime();
+    return result.printers.imin.ready;
+  } catch {
+    return false;
+  }
+};
+
+export const getPrintingRuntimeState = (): PrintingRuntimeState => ({
+  ...runtimeState,
+});

--- a/src/printing/printing-runtime.ts
+++ b/src/printing/printing-runtime.ts
@@ -21,7 +21,7 @@ const statusFromResult = (
 
 export const initializePrintingRuntime =
   async (): Promise<PrintersInitializationResult> => {
-    if (runtimeState.result) return runtimeState.result;
+    if (runtimeState.result?.printers.imin.ready) return runtimeState.result;
     if (runtimePromise) return runtimePromise;
 
     runtimeState = {
@@ -69,7 +69,6 @@ export const isFalconPrintingEnabled = (): boolean =>
 
 export const waitForPrinterInitialization = async (): Promise<boolean> => {
   if (runtimeState.status === "ready") return true;
-  if (runtimeState.status === "disabled") return false;
 
   try {
     const result = await initializePrintingRuntime();

--- a/src/printing/receipt-builder.ts
+++ b/src/printing/receipt-builder.ts
@@ -1,0 +1,133 @@
+import type { Company } from "@/company/types";
+import {
+  fullName,
+  isBusinessCustomer,
+  isNaturalCustomer,
+} from "@/customer/utils";
+import type { Document } from "@/document/types";
+import { correlative, isBillableDocument } from "@/document/utils";
+import type { Order, Payment } from "@/order/types";
+import type { ReceiptPrintData } from "@/printing/types";
+
+type BuildReceiptPrintDataParams = {
+  order: Order;
+  company: Company;
+  document: Document;
+};
+
+const toIsoString = (date: Date | string | undefined): string | undefined => {
+  if (!date) return undefined;
+  if (typeof date === "string") return date;
+  return date.toISOString();
+};
+
+const buildCustomer = (
+  customer: Order["customer"],
+): ReceiptPrintData["customer"] => {
+  if (!customer) return undefined;
+
+  return {
+    name: fullName(customer),
+    documentType: customer.documentType,
+    documentNumber: customer.documentNumber,
+    address: customer.address,
+    email:
+      isBusinessCustomer(customer) || isNaturalCustomer(customer)
+        ? customer.email
+        : undefined,
+    phone:
+      isBusinessCustomer(customer) || isNaturalCustomer(customer)
+        ? customer.phoneNumber
+        : undefined,
+  };
+};
+
+const buildPayment = (
+  payment: Payment,
+): ReceiptPrintData["order"]["payments"][number] => {
+  if (payment.method === "cash") {
+    return {
+      id: payment.id,
+      method: payment.method,
+      amount: payment.amount,
+      receivedAmount: payment.received_amount,
+      change: payment.change,
+    };
+  }
+
+  if (payment.method === "wallet") {
+    return {
+      id: payment.id,
+      method: payment.method,
+      amount: payment.amount,
+      operationCode: payment.operationCode,
+      walletName: payment.name,
+    };
+  }
+
+  return {
+    id: payment.id,
+    method: payment.method,
+    amount: payment.amount,
+  };
+};
+
+export const buildReceiptPrintData = ({
+  order,
+  company,
+  document,
+}: BuildReceiptPrintDataParams): ReceiptPrintData => ({
+  company: {
+    commercialName: company.subName,
+    legalName: company.name,
+    ruc: company.ruc,
+    address: company.address,
+    location: [company.district, company.provincial, company.department]
+      .filter(Boolean)
+      .join("-"),
+    email: company.email,
+    phone: company.phone,
+    logoUrl: company.logo?.url,
+  },
+  document: {
+    type: document.documentType,
+    series: document.series,
+    number: document.number,
+    correlative: correlative(document),
+    dateOfIssue: toIsoString(document.dateOfIssue)!,
+    status: document.status,
+    cancellationReason:
+      document.status === "cancelled" ? document.cancellationReason : undefined,
+    qr: isBillableDocument(document) ? document.qr : undefined,
+    hash: isBillableDocument(document) ? document.hash : undefined,
+    xml: isBillableDocument(document) ? document.xml : undefined,
+    issuedToTaxEntity: document.issuedToTaxEntity,
+    issuedAt: toIsoString(document.issuedAt),
+  },
+  customer: buildCustomer(order.customer),
+  order: {
+    id: order.id!,
+    date: toIsoString(order.createdAt)!,
+    items: order.orderItems.map((item) => ({
+      id: item.id,
+      productId: item.productId,
+      sku: item.productSku,
+      name: item.productName,
+      quantity: item.quantity,
+      unitType: item.unitType,
+      unitPrice: item.productPrice,
+      netTotal: item.netTotal,
+      discountAmount: item.discountAmount,
+      total: item.total,
+    })),
+    payments: order.payments.map(buildPayment),
+    subtotal: order.netTotal,
+    discount: order.discountAmount,
+    total: order.total,
+  },
+  paper: {
+    widthMm: 80,
+    columns: 48,
+  },
+  fallbackPdfUrl: `/api/orders/${order.id}/documents`,
+});

--- a/src/printing/types.ts
+++ b/src/printing/types.ts
@@ -1,0 +1,148 @@
+import type { CustomerDocumentType } from "@/customer/types";
+import type { DocumentStatus, DocumentType } from "@/document/types";
+import type { PaymentMethod } from "@/order/types";
+import type { KG_UNIT_TYPE, UNIT_UNIT_TYPE } from "@/product/types";
+
+type UnitType = typeof KG_UNIT_TYPE | typeof UNIT_UNIT_TYPE;
+
+export type PrintFailureReason =
+  | "sdk_unavailable"
+  | "plugin_unavailable"
+  | "printer_not_connected"
+  | "printer_head_open"
+  | "paper_out"
+  | "paper_low"
+  | "printer_unknown_error"
+  | "data_fetch_failed"
+  | "render_failed"
+  | "print_failed";
+
+export type PrintMode = "imin" | "pdf";
+
+export type PrintResult =
+  | {
+      success: true;
+      mode: "imin";
+      message?: string;
+    }
+  | {
+      success: true;
+      mode: "pdf";
+      fallbackReason?: PrintFailureReason;
+      message: string;
+    }
+  | {
+      success: false;
+      mode: PrintMode;
+      reason: PrintFailureReason;
+      message: string;
+    };
+
+export type PrinterAdapter = {
+  isAvailable: () => boolean;
+  printReceipt: (data: ReceiptPrintData) => Promise<PrintResult>;
+};
+
+export type PrintAlignment = "left" | "center" | "right";
+
+export type PrinterStatus = {
+  code?: number;
+  ready: boolean;
+  reason?: PrintFailureReason;
+  message: string;
+};
+
+export type PrintCommand =
+  | {
+      type: "text";
+      value: string;
+      align?: PrintAlignment;
+      size?: number;
+      bold?: boolean;
+    }
+  | {
+      type: "columns";
+      values: string[];
+      widths: number[];
+      aligns: PrintAlignment[];
+      bold?: boolean;
+    }
+  | {
+      type: "qr";
+      value: string;
+    }
+  | {
+      type: "feed";
+      lines: number;
+    }
+  | {
+      type: "cut";
+    };
+
+export type ReceiptPrintData = {
+  company: {
+    commercialName?: string;
+    legalName?: string;
+    ruc?: string;
+    address?: string;
+    location?: string;
+    email?: string;
+    phone?: string;
+    logoUrl?: string;
+  };
+  document: {
+    type: DocumentType;
+    series: string;
+    number: string;
+    correlative: string;
+    dateOfIssue: string;
+    status: DocumentStatus;
+    cancellationReason?: string;
+    qr?: string;
+    hash?: string;
+    xml?: string;
+    issuedToTaxEntity?: boolean;
+    issuedAt?: string;
+  };
+  customer?: {
+    name: string;
+    documentType?: CustomerDocumentType;
+    documentNumber?: string;
+    address?: string;
+    email?: string;
+    phone?: string;
+  };
+  order: {
+    id: string;
+    date: string;
+    items: Array<{
+      id: string;
+      productId: string;
+      sku?: string;
+      name: string;
+      quantity: number;
+      unitType: UnitType;
+      unitPrice: number;
+      netTotal: number;
+      discountAmount: number;
+      total: number;
+    }>;
+    payments: Array<{
+      id?: string;
+      method: PaymentMethod;
+      amount: number;
+      operationCode?: string;
+      walletName?: string;
+      receivedAmount?: number;
+      change?: number;
+    }>;
+    subtotal: number;
+    discount: number;
+    total: number;
+  };
+  paper: {
+    widthMm: 80;
+    columns: 48;
+  };
+  fallbackPdfUrl: string;
+};

--- a/src/printing/types.ts
+++ b/src/printing/types.ts
@@ -19,6 +19,10 @@ export type PrintFailureReason =
 
 export type PrintMode = "imin" | "pdf";
 
+export type PrinterId = "imin";
+
+export type PrinterInitializationStatus = "ready" | "unavailable" | "error";
+
 export type PrintResult =
   | {
       success: true;
@@ -40,6 +44,8 @@ export type PrintResult =
 
 export type PrinterAdapter = {
   isAvailable: () => boolean;
+  initialize?: () => Promise<PrinterStatus>;
+  getStatus?: () => Promise<PrinterStatus>;
   printReceipt: (data: ReceiptPrintData) => Promise<PrintResult>;
 };
 
@@ -50,6 +56,19 @@ export type PrinterStatus = {
   ready: boolean;
   reason?: PrintFailureReason;
   message: string;
+};
+
+export type PrinterHealth = {
+  id: PrinterId;
+  status: PrinterInitializationStatus;
+  ready: boolean;
+  reason?: PrintFailureReason;
+  message: string;
+};
+
+export type PrintersInitializationResult = {
+  initializedAt: string;
+  printers: Record<PrinterId, PrinterHealth>;
 };
 
 export type PrintCommand =


### PR DESCRIPTION
## Summary
- support additional iMin WebSocket response shapes, including nested value payloads
- send Falcon 1 column print parameters with 80mm width and size over WebSocket
- avoid treating a browser WebSocket constructor as a ready printer service
- retry failed iMin initialization attempts instead of caching printer/plugin errors
- add WebSocket contract diagnostics for hardware validation

## Validation
- npx eslint src/printing src/order/components/order-print-button.tsx src/new-order/components/create-order-modal/payment-modal.tsx 'src/app/api/orders/[id]/print-data/route.ts'
- npm run build:dev

## Manual validation needed
- Falcon 1 thermal print with active WebSocket service
- physical error fallback: no paper, lid open, service stopped, printer unavailable
- confirm WebSocket response contract and printColumnsText parameter shape