### PR TITLE
feat: add iMin Falcon printing flow

### DIFF
--- a/src/app/[subdomain]/dashboard/layout.tsx
+++ b/src/app/[subdomain]/dashboard/layout.tsx
@@ -13,6 +13,7 @@ import { RealtimeProvider } from "@/shared/components/layout/realtime-provider";
 import { getLastOpenCashShift, userExists } from "@/cash-shift/db_repository";
 import { getCompanyFeatures } from "@/feature-flags";
 import { FeatureFlagsProvider } from "@/feature-flags/client";
+import { PrintingProvider } from "@/printing/printing-provider";
 
 export default async function DashboardLayout({
   children,
@@ -45,25 +46,27 @@ export default async function DashboardLayout({
     <CompanyProvider company={companyResponse.data}>
       <FeatureFlagsProvider features={featureFlags}>
         <RealtimeProvider>
-          <OrderFormProvider>
-            <ProductFormProvider>
-              <CategoryStoreProvider>
-                <CashShiftProvider
-                  cashShiftResponse={
-                    userPresent
-                      ? cashShiftResponse
-                      : {
-                          success: false,
-                          message: "Usuario no autenticado",
-                          type: "AuthError",
-                        }
-                  }
-                >
-                  <CategoriesLoader>{children}</CategoriesLoader>
-                </CashShiftProvider>
-              </CategoryStoreProvider>
-            </ProductFormProvider>
-          </OrderFormProvider>
+          <PrintingProvider>
+            <OrderFormProvider>
+              <ProductFormProvider>
+                <CategoryStoreProvider>
+                  <CashShiftProvider
+                    cashShiftResponse={
+                      userPresent
+                        ? cashShiftResponse
+                        : {
+                            success: false,
+                            message: "Usuario no autenticado",
+                            type: "AuthError",
+                          }
+                    }
+                  >
+                    <CategoriesLoader>{children}</CategoriesLoader>
+                  </CashShiftProvider>
+                </CategoryStoreProvider>
+              </ProductFormProvider>
+            </OrderFormProvider>
+          </PrintingProvider>
         </RealtimeProvider>
       </FeatureFlagsProvider>
     </CompanyProvider>

--- a/src/app/api/orders/[id]/print-data/route.ts
+++ b/src/app/api/orders/[id]/print-data/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+
+import { getCompany } from "@/company/db_repository";
+import { findBillingDocumentFor } from "@/document/db_repository";
+import { getSession } from "@/lib/auth";
+import { errorResponse } from "@/lib/utils";
+import { find } from "@/order/db_repository";
+import { buildReceiptPrintData } from "@/printing/receipt-builder";
+
+export async function GET(
+  _req: Request,
+  props: { params: Promise<{ id: string }> },
+) {
+  const params = await props.params;
+  const session = await getSession();
+
+  if (!session.user) {
+    return NextResponse.json(
+      { success: false, message: "Unauthenticated user" },
+      { status: 401 },
+    );
+  }
+
+  const [companyResponse, orderResponse, documentResponse] = await Promise.all([
+    getCompany(session.user.companyId),
+    find(params.id, session.user.companyId),
+    findBillingDocumentFor(params.id),
+  ]);
+
+  if (!companyResponse.success) {
+    return NextResponse.json(errorResponse("No se encontro empresa"), {
+      status: 404,
+    });
+  }
+
+  if (!orderResponse.success || !documentResponse.success) {
+    return NextResponse.json(
+      errorResponse("No se encontro pedido o documento"),
+      { status: 404 },
+    );
+  }
+
+  return NextResponse.json({
+    success: true,
+    data: buildReceiptPrintData({
+      order: orderResponse.data,
+      company: companyResponse.data,
+      document: documentResponse.data,
+    }),
+  });
+}

--- a/src/new-order/components/create-order-modal/payment-modal.tsx
+++ b/src/new-order/components/create-order-modal/payment-modal.tsx
@@ -28,6 +28,7 @@ import { useUserSession } from "@/lib/use-user-session";
 import DiscountFields from "@/new-order/components/create-order-modal/discount-fields";
 import { useCompany } from "@/lib/use-company";
 import useSignOut from "@/lib/use-sign-out";
+import { printOrderReceipt } from "@/printing/print-order-receipt";
 
 const PaymentViews = {
   none: NonePayment,
@@ -48,6 +49,40 @@ const allowedCompanyIdsToSeDiscount = (
 
 const companyHasDiscountFeature = (companyId: string) =>
   allowedCompanyIdsToSeDiscount.includes(companyId);
+
+const CreateOrderButton = ({
+  amountIsInvalid,
+  creatingOrder,
+  onCreateOrder,
+  paymentMode,
+}: {
+  amountIsInvalid: boolean;
+  creatingOrder: boolean;
+  onCreateOrder: () => void;
+  paymentMode: keyof typeof PaymentViews;
+}) => {
+  if (creatingOrder) {
+    return (
+      <Button className="btn-success" type="button" disabled={true}>
+        <ReloadIcon className="mr-2 h-4 w-4 animate-spin" />
+      </Button>
+    );
+  }
+
+  if (paymentMode !== "none") {
+    return (
+      <Button type="button" disabled={amountIsInvalid} onClick={onCreateOrder}>
+        Realiza pago
+      </Button>
+    );
+  }
+
+  return (
+    <Button type="button" disabled={true}>
+      Realiza pago
+    </Button>
+  );
+};
 
 const PaymentModal: React.FC<CreateOrderModalProps> = ({
   isOpen,
@@ -85,7 +120,18 @@ const PaymentModal: React.FC<CreateOrderModalProps> = ({
       });
       reset();
       onOpenChange(false);
-      window.open(`/api/orders/${response.data.order.id}/documents`, "_blank");
+      const printResult = await printOrderReceipt(response.data.order.id!);
+
+      if (printResult.success && printResult.mode === "pdf") {
+        toast({
+          description: printResult.message,
+        });
+      } else if (!printResult.success) {
+        toast({
+          variant: "destructive",
+          description: printResult.message,
+        });
+      }
     } else {
       if (response.type === "CompanyInactive") {
         toast({
@@ -106,37 +152,6 @@ const PaymentModal: React.FC<CreateOrderModalProps> = ({
     setCreatingOrder(false);
   };
 
-  const CreateOrderButton = ({
-    amountIsInvalid,
-  }: {
-    amountIsInvalid: boolean;
-    paidAmount: number;
-    total: number;
-  }) => {
-    if (creatingOrder) {
-      return (
-        <Button className="btn-success" type="button" disabled={true}>
-          <ReloadIcon className="mr-2 h-4 w-4 animate-spin" />
-        </Button>
-      );
-    } else if (paymentMode !== "none") {
-      return (
-        <Button
-          type="button"
-          disabled={amountIsInvalid}
-          onClick={handleOrderCreation}
-        >
-          Realiza pago
-        </Button>
-      );
-    } else {
-      return (
-        <Button type="button" disabled={true}>
-          Realiza pago
-        </Button>
-      );
-    }
-  };
   const handleOpenChange = (isOpen: boolean) => {
     if (!isOpen) {
       setDiscount(undefined);
@@ -168,14 +183,14 @@ const PaymentModal: React.FC<CreateOrderModalProps> = ({
           </div>
           {paymentMode !== "none" && (
             <div className="flex justify-center mt-2">
-            <Button
-              type="button"
-              variant="link"
-              onClick={resetPayment}
-              className="mt-2 md:absolute md:top-0 md:right-0 md:py-0"
-            >
-              CAMBIAR MÉTODO
-            </Button>
+              <Button
+                type="button"
+                variant="link"
+                onClick={resetPayment}
+                className="mt-2 md:absolute md:top-0 md:right-0 md:py-0"
+              >
+                CAMBIAR MÉTODO
+              </Button>
             </div>
           )}
           <PaymentView />
@@ -186,8 +201,9 @@ const PaymentModal: React.FC<CreateOrderModalProps> = ({
         <DialogFooter>
           <CreateOrderButton
             amountIsInvalid={getPaidAmount() !== order.total}
-            paidAmount={getPaidAmount()}
-            total={order.total}
+            creatingOrder={creatingOrder}
+            onCreateOrder={handleOrderCreation}
+            paymentMode={paymentMode}
           />
         </DialogFooter>
       </DialogContent>

--- a/src/order/components/order-data.tsx
+++ b/src/order/components/order-data.tsx
@@ -7,11 +7,10 @@ import {
 } from "@/shared/components/ui/card";
 import {
   formatPrice,
-  localizeDate,
   paymentMethodToText,
   shortLocalizeDate,
 } from "@/lib/utils";
-import { FileCode,Printer } from "lucide-react";
+import { FileCode } from "lucide-react";
 import { buttonVariants } from "@/shared/components/ui/button";
 import { UNIT_TYPE_MAPPER } from "@/product/constants";
 import { fullName } from "@/customer/utils";
@@ -20,15 +19,18 @@ import CancelOrderButton from "@/order/components/cancel-order-button";
 import { findBillingDocumentFor } from "@/document/db_repository";
 import { correlative } from "@/document/utils";
 import { Badge } from "@/shared/components/ui/badge";
+import OrderPrintButton from "@/order/components/order-print-button";
 
 export default async function OrderData({ order }: { order: Order }) {
   const documentResponse = await findBillingDocumentFor(order.id!);
 
-  if(!documentResponse.success) {
-    return <p>No se encontro el documento</p>
+  if (!documentResponse.success) {
+    return <p>No se encontro el documento</p>;
   }
 
-  const hasADiscount = order.orderItems.some((orderItem) => orderItem.discountAmount > 0);
+  const hasADiscount = order.orderItems.some(
+    (orderItem) => orderItem.discountAmount > 0,
+  );
 
   return (
     <div className="h-full mt-8 flex justify-center">
@@ -52,23 +54,17 @@ export default async function OrderData({ order }: { order: Order }) {
             )}
           </CardTitle>
           <div className="flex space-x-2">
-            <a
-              className={buttonVariants({variant: "ghost", size: "icon"})}
-              href={`/api/orders/${order.id}/documents`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Printer className="cursor-pointer"/>
-            </a>
-            {documentResponse.data.documentType === "invoice" || documentResponse.data.documentType === "receipt" && (
-                <a
-                  className={buttonVariants({variant: "ghost", size: "icon"})}
-                  href={`${documentResponse.data.xml}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <FileCode/>
-                </a>
+            <OrderPrintButton orderId={order.id!} />
+            {(documentResponse.data.documentType === "invoice" ||
+              documentResponse.data.documentType === "receipt") && (
+              <a
+                className={buttonVariants({ variant: "ghost", size: "icon" })}
+                href={`${documentResponse.data.xml}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <FileCode />
+              </a>
             )}
             {differenceInHours(new Date(), order.createdAt!) < 168 &&
               order.status === "completed" && (
@@ -84,10 +80,10 @@ export default async function OrderData({ order }: { order: Order }) {
         <CardContent>
           <table className="table-auto border w-full">
             <tbody>
-            <tr>
-              <td className="pl-2 border w-13 py-1 bg-slate-100 font-light w-56">
-                Cliente
-              </td>
+              <tr>
+                <td className="pl-2 border w-13 py-1 bg-slate-100 font-light w-56">
+                  Cliente
+                </td>
                 <td className="pl-2 border py-1">
                   {order.customer ? fullName(order.customer) : "-"}
                 </td>
@@ -122,72 +118,75 @@ export default async function OrderData({ order }: { order: Order }) {
           <div className="overflow-y-auto w-screen md:w-full">
             <table className="table-auto border min-w-[600px] md:w-full mt-8">
               <thead>
-              <tr>
-                <th className="bg-slate-100 pl-2 border py-1 font-light">
-                  Cantidad
-                </th>
-                <th className="bg-slate-100 pl-2 border py-1 font-light">
-                  Producto
-                </th>
-                <th className="bg-slate-100 pl-2 border py-1 font-light">
-                  Precio
-                </th>
-                {hasADiscount && (
+                <tr>
                   <th className="bg-slate-100 pl-2 border py-1 font-light">
-                    Descuento
+                    Cantidad
                   </th>
-                )}
-                <th className="bg-slate-100 pl-2 border py-1 font-light">
-                  Total
-                </th>
-              </tr>
+                  <th className="bg-slate-100 pl-2 border py-1 font-light">
+                    Producto
+                  </th>
+                  <th className="bg-slate-100 pl-2 border py-1 font-light">
+                    Precio
+                  </th>
+                  {hasADiscount && (
+                    <th className="bg-slate-100 pl-2 border py-1 font-light">
+                      Descuento
+                    </th>
+                  )}
+                  <th className="bg-slate-100 pl-2 border py-1 font-light">
+                    Total
+                  </th>
+                </tr>
               </thead>
               <tbody>
-              {order.orderItems.map((orderItem) => (
-                <tr key={orderItem.id}>
-                  <td className="pl-2 border py-1">
-                    {orderItem.quantity} {UNIT_TYPE_MAPPER[orderItem.unitType]}
-                  </td>
-                  <td className="pl-2 border py-1">{orderItem.productName}</td>
-                  <td className="pl-2 border py-1">
-                    {formatPrice(orderItem.productPrice)}
-                  </td>
-                  {hasADiscount && (
+                {order.orderItems.map((orderItem) => (
+                  <tr key={orderItem.id}>
                     <td className="pl-2 border py-1">
-                      {formatPrice(orderItem.discountAmount)}
+                      {orderItem.quantity}{" "}
+                      {UNIT_TYPE_MAPPER[orderItem.unitType]}
                     </td>
-                  )}
-                  <td className="pl-2 border py-1">
-                    {formatPrice(orderItem.total)}
-                  </td>
-                </tr>
-              ))}
+                    <td className="pl-2 border py-1">
+                      {orderItem.productName}
+                    </td>
+                    <td className="pl-2 border py-1">
+                      {formatPrice(orderItem.productPrice)}
+                    </td>
+                    {hasADiscount && (
+                      <td className="pl-2 border py-1">
+                        {formatPrice(orderItem.discountAmount)}
+                      </td>
+                    )}
+                    <td className="pl-2 border py-1">
+                      {formatPrice(orderItem.total)}
+                    </td>
+                  </tr>
+                ))}
               </tbody>
             </table>
           </div>
           <div className="w-full flex justify-between mt-8">
             <table className="table-auto border w-64">
               <thead>
-              <tr>
-                <th className="bg-slate-100 pl-2 border py-1 font-light">
-                  Método de pago
-                </th>
-                <th className="bg-slate-100 pl-2 border py-1 font-light">
-                  Monto
-                </th>
-              </tr>
+                <tr>
+                  <th className="bg-slate-100 pl-2 border py-1 font-light">
+                    Método de pago
+                  </th>
+                  <th className="bg-slate-100 pl-2 border py-1 font-light">
+                    Monto
+                  </th>
+                </tr>
               </thead>
               <tbody>
-              {order.payments.map((payment) => (
-                <tr key={payment.id}>
-                  <td className="pl-2 border py-1">
-                    {paymentMethodToText(payment.method)}
-                  </td>
-                  <td className="pl-2 border py-1">
-                    {formatPrice(payment.amount)}
-                  </td>
-                </tr>
-              ))}
+                {order.payments.map((payment) => (
+                  <tr key={payment.id}>
+                    <td className="pl-2 border py-1">
+                      {paymentMethodToText(payment.method)}
+                    </td>
+                    <td className="pl-2 border py-1">
+                      {formatPrice(payment.amount)}
+                    </td>
+                  </tr>
+                ))}
               </tbody>
             </table>
             <div className="w-56 flex flex-col">

--- a/src/order/components/order-print-button.tsx
+++ b/src/order/components/order-print-button.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Loader2, Printer } from "lucide-react";
+import { useState } from "react";
+
+import { printOrderReceipt } from "@/printing/print-order-receipt";
+import { Button } from "@/shared/components/ui/button";
+import { useToast } from "@/shared/components/ui/use-toast";
+
+export default function OrderPrintButton({ orderId }: { orderId: string }) {
+  const { toast } = useToast();
+  const [printing, setPrinting] = useState(false);
+
+  const handlePrint = async () => {
+    setPrinting(true);
+
+    try {
+      const result = await printOrderReceipt(orderId);
+
+      if (result.success && result.mode === "pdf") {
+        toast({
+          description: result.message,
+        });
+      } else if (!result.success) {
+        toast({
+          variant: "destructive",
+          description: result.message,
+        });
+      }
+    } finally {
+      setPrinting(false);
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      aria-label="Imprimir comprobante"
+      disabled={printing}
+      onClick={handlePrint}
+    >
+      {printing ? (
+        <Loader2 className="h-4 w-4 animate-spin" />
+      ) : (
+        <Printer className="cursor-pointer" />
+      )}
+    </Button>
+  );
+}

--- a/src/printing/init-printers.ts
+++ b/src/printing/init-printers.ts
@@ -1,9 +1,6 @@
 "use client";
 
-import {
-  iminSdkWrapper,
-  messageForPrintFailure,
-} from "@/printing/printers/imin/imin-sdk-wrapper";
+import { iminSdkWrapper } from "@/printing/printers/imin/imin-sdk-wrapper";
 import type {
   PrinterHealth,
   PrinterStatus,
@@ -21,17 +18,7 @@ const healthFromStatus = (status: PrinterStatus): PrinterHealth => ({
   message: status.message,
 });
 
-const unavailableHealth = (): PrinterHealth => ({
-  id: "imin",
-  status: "unavailable",
-  ready: false,
-  reason: "sdk_unavailable",
-  message: messageForPrintFailure("sdk_unavailable"),
-});
-
 const initializeImin = async (): Promise<PrinterHealth> => {
-  if (!iminSdkWrapper.isAvailable()) return unavailableHealth();
-
   const initStatus = await iminSdkWrapper.initialize();
   if (!initStatus.ready) return healthFromStatus(initStatus);
 
@@ -42,18 +29,20 @@ const initializeImin = async (): Promise<PrinterHealth> => {
 };
 
 export const initPrinters = async (): Promise<PrintersInitializationResult> => {
-  if (initializationResult) return initializationResult;
+  if (initializationResult?.printers.imin.ready) return initializationResult;
   if (initializationPromise) return initializationPromise;
 
   initializationPromise = initializeImin()
     .then((imin) => {
-      initializationResult = {
+      const result: PrintersInitializationResult = {
         initializedAt: new Date().toISOString(),
         printers: {
           imin,
         },
       };
-      return initializationResult;
+
+      if (imin.ready) initializationResult = result;
+      return result;
     })
     .finally(() => {
       initializationPromise = undefined;

--- a/src/printing/init-printers.ts
+++ b/src/printing/init-printers.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import {
+  iminSdkWrapper,
+  messageForPrintFailure,
+} from "@/printing/printers/imin/imin-sdk-wrapper";
+import type {
+  PrinterHealth,
+  PrinterStatus,
+  PrintersInitializationResult,
+} from "@/printing/types";
+
+let initializationResult: PrintersInitializationResult | undefined;
+let initializationPromise: Promise<PrintersInitializationResult> | undefined;
+
+const healthFromStatus = (status: PrinterStatus): PrinterHealth => ({
+  id: "imin",
+  status: status.ready ? "ready" : "error",
+  ready: status.ready,
+  reason: status.reason,
+  message: status.message,
+});
+
+const unavailableHealth = (): PrinterHealth => ({
+  id: "imin",
+  status: "unavailable",
+  ready: false,
+  reason: "sdk_unavailable",
+  message: messageForPrintFailure("sdk_unavailable"),
+});
+
+const initializeImin = async (): Promise<PrinterHealth> => {
+  if (!iminSdkWrapper.isAvailable()) return unavailableHealth();
+
+  const initStatus = await iminSdkWrapper.initialize();
+  if (!initStatus.ready) return healthFromStatus(initStatus);
+
+  const configStatus = await iminSdkWrapper.configure80mm();
+  if (!configStatus.ready) return healthFromStatus(configStatus);
+
+  return healthFromStatus(await iminSdkWrapper.getStatus());
+};
+
+export const initPrinters = async (): Promise<PrintersInitializationResult> => {
+  if (initializationResult) return initializationResult;
+  if (initializationPromise) return initializationPromise;
+
+  initializationPromise = initializeImin()
+    .then((imin) => {
+      initializationResult = {
+        initializedAt: new Date().toISOString(),
+        printers: {
+          imin,
+        },
+      };
+      return initializationResult;
+    })
+    .finally(() => {
+      initializationPromise = undefined;
+    });
+
+  return initializationPromise;
+};
+
+export const resetPrintersInitialization = () => {
+  initializationResult = undefined;
+  initializationPromise = undefined;
+  iminSdkWrapper.resetConnection();
+};

--- a/src/printing/print-order-receipt.ts
+++ b/src/printing/print-order-receipt.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { iminPrinter } from "@/printing/printers/imin/imin-printer";
+import type {
+  PrintFailureReason,
+  PrintResult,
+  ReceiptPrintData,
+} from "@/printing/types";
+
+type PrintDataResponse =
+  | {
+      success: true;
+      data: ReceiptPrintData;
+    }
+  | {
+      success: false;
+      message?: string;
+    };
+
+export const orderDocumentPdfUrl = (orderId: string) =>
+  `/api/orders/${orderId}/documents`;
+
+export const orderPrintDataUrl = (orderId: string) =>
+  `/api/orders/${orderId}/print-data`;
+
+const openPdfFallback = (url: string) => {
+  window.open(url, "_blank");
+};
+
+const pdfFallbackResult = (
+  reason: PrintFailureReason,
+  message = "Se abrio el comprobante en PDF.",
+): PrintResult => ({
+  success: true,
+  mode: "pdf",
+  fallbackReason: reason,
+  message,
+});
+
+export const printOrderReceipt = async (orderId: string): Promise<PrintResult> => {
+  const defaultPdfUrl = orderDocumentPdfUrl(orderId);
+
+  let receiptData: ReceiptPrintData;
+
+  try {
+    const response = await fetch(orderPrintDataUrl(orderId), {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error("Print data request failed");
+    }
+
+    const payload = (await response.json()) as PrintDataResponse;
+
+    if (!payload.success) {
+      throw new Error(payload.message ?? "Print data response failed");
+    }
+
+    receiptData = payload.data;
+  } catch {
+    openPdfFallback(defaultPdfUrl);
+    return pdfFallbackResult(
+      "data_fetch_failed",
+      "No se pudo preparar la impresion directa. Se abrio el PDF.",
+    );
+  }
+
+  const fallbackPdfUrl = receiptData.fallbackPdfUrl || defaultPdfUrl;
+
+  if (!iminPrinter.isAvailable()) {
+    openPdfFallback(fallbackPdfUrl);
+    return pdfFallbackResult(
+      "sdk_unavailable",
+      "Impresora iMin no disponible. Se abrio el PDF.",
+    );
+  }
+
+  const printResult = await iminPrinter.printReceipt(receiptData);
+
+  if (!printResult.success) {
+    openPdfFallback(fallbackPdfUrl);
+    return pdfFallbackResult(
+      printResult.reason,
+      `${printResult.message} Se abrio el PDF.`,
+    );
+  }
+
+  return printResult;
+};

--- a/src/printing/print-order-receipt.ts
+++ b/src/printing/print-order-receipt.ts
@@ -1,6 +1,11 @@
 "use client";
 
 import { iminPrinter } from "@/printing/printers/imin/imin-printer";
+import {
+  getPrintingRuntimeState,
+  isFalconPrintingEnabled,
+  waitForPrinterInitialization,
+} from "@/printing/printing-runtime";
 import type {
   PrintFailureReason,
   PrintResult,
@@ -39,6 +44,20 @@ const pdfFallbackResult = (
 
 export const printOrderReceipt = async (orderId: string): Promise<PrintResult> => {
   const defaultPdfUrl = orderDocumentPdfUrl(orderId);
+
+  if (
+    !isFalconPrintingEnabled() &&
+    !(await waitForPrinterInitialization())
+  ) {
+    const runtimeHealth = getPrintingRuntimeState().result?.printers.imin;
+    const fallbackReason = runtimeHealth?.reason ?? "sdk_unavailable";
+
+    openPdfFallback(defaultPdfUrl);
+    return pdfFallbackResult(
+      fallbackReason,
+      `${runtimeHealth?.message ?? "Impresora iMin no disponible."} Se abrio el PDF.`,
+    );
+  }
 
   let receiptData: ReceiptPrintData;
 

--- a/src/printing/printers/imin/imin-printer.ts
+++ b/src/printing/printers/imin/imin-printer.ts
@@ -10,6 +10,7 @@ import {
   iminSdkWrapper,
   messageForPrintFailure,
 } from "@/printing/printers/imin/imin-sdk-wrapper";
+import { initPrinters } from "@/printing/init-printers";
 import { buildThermalReceiptCommands } from "@/printing/printers/imin/thermal-receipt-renderer";
 
 const failedResult = (
@@ -45,6 +46,7 @@ const executeCommand = async (
         command.values,
         command.widths,
         command.aligns,
+        command.bold,
       );
     case "qr":
       return iminSdkWrapper.printQr(command.value);
@@ -58,16 +60,25 @@ const executeCommand = async (
 export const iminPrinter: PrinterAdapter = {
   isAvailable: () => iminSdkWrapper.isAvailable(),
 
+  initialize: () =>
+    initPrinters().then((result) => {
+      const health = result.printers.imin;
+      return {
+        ready: health.ready,
+        reason: health.reason,
+        message: health.message,
+      };
+    }),
+
+  getStatus: () => iminSdkWrapper.getStatus(),
+
   async printReceipt(data: ReceiptPrintData): Promise<PrintResult> {
     if (!iminSdkWrapper.isAvailable()) {
       return failedResult("sdk_unavailable");
     }
 
-    const initResult = ensureReady(await iminSdkWrapper.initialize());
+    const initResult = ensureReady(await this.initialize!());
     if (initResult) return initResult;
-
-    const configResult = ensureReady(await iminSdkWrapper.configure80mm());
-    if (configResult) return configResult;
 
     const statusResult = ensureReady(await iminSdkWrapper.getStatus());
     if (statusResult) return statusResult;
@@ -80,8 +91,16 @@ export const iminPrinter: PrinterAdapter = {
     }
 
     for (const command of commands) {
-      const commandStatus = ensureReady(await executeCommand(command));
-      if (commandStatus) return commandStatus;
+      const rawCommandStatus = await executeCommand(command);
+      const commandStatus = ensureReady(rawCommandStatus);
+      if (commandStatus) {
+        if (command.type === "cut") {
+          console.warn("iMin receipt printed, but paper cut failed", rawCommandStatus);
+          continue;
+        }
+
+        return commandStatus;
+      }
     }
 
     return {

--- a/src/printing/printers/imin/imin-printer.ts
+++ b/src/printing/printers/imin/imin-printer.ts
@@ -73,10 +73,6 @@ export const iminPrinter: PrinterAdapter = {
   getStatus: () => iminSdkWrapper.getStatus(),
 
   async printReceipt(data: ReceiptPrintData): Promise<PrintResult> {
-    if (!iminSdkWrapper.isAvailable()) {
-      return failedResult("sdk_unavailable");
-    }
-
     const initResult = ensureReady(await this.initialize!());
     if (initResult) return initResult;
 

--- a/src/printing/printers/imin/imin-printer.ts
+++ b/src/printing/printers/imin/imin-printer.ts
@@ -1,0 +1,98 @@
+import type {
+  PrintCommand,
+  PrintFailureReason,
+  PrintResult,
+  PrinterAdapter,
+  PrinterStatus,
+  ReceiptPrintData,
+} from "@/printing/types";
+import {
+  iminSdkWrapper,
+  messageForPrintFailure,
+} from "@/printing/printers/imin/imin-sdk-wrapper";
+import { buildThermalReceiptCommands } from "@/printing/printers/imin/thermal-receipt-renderer";
+
+const failedResult = (
+  reason: PrintFailureReason,
+  message = messageForPrintFailure(reason),
+): PrintResult => ({
+  success: false,
+  mode: "imin",
+  reason,
+  message,
+});
+
+const statusToResult = (status: PrinterStatus): PrintResult =>
+  failedResult(status.reason ?? "printer_unknown_error", status.message);
+
+const ensureReady = (status: PrinterStatus): PrintResult | undefined => {
+  if (status.ready) return undefined;
+  return statusToResult(status);
+};
+
+const executeCommand = async (
+  command: PrintCommand,
+): Promise<PrinterStatus> => {
+  switch (command.type) {
+    case "text":
+      return iminSdkWrapper.printText(command.value, {
+        align: command.align,
+        bold: command.bold,
+        size: command.size,
+      });
+    case "columns":
+      return iminSdkWrapper.printColumns(
+        command.values,
+        command.widths,
+        command.aligns,
+      );
+    case "qr":
+      return iminSdkWrapper.printQr(command.value);
+    case "feed":
+      return iminSdkWrapper.feed(command.lines);
+    case "cut":
+      return iminSdkWrapper.cut();
+  }
+};
+
+export const iminPrinter: PrinterAdapter = {
+  isAvailable: () => iminSdkWrapper.isAvailable(),
+
+  async printReceipt(data: ReceiptPrintData): Promise<PrintResult> {
+    if (!iminSdkWrapper.isAvailable()) {
+      return failedResult("sdk_unavailable");
+    }
+
+    const initResult = ensureReady(await iminSdkWrapper.initialize());
+    if (initResult) return initResult;
+
+    const configResult = ensureReady(await iminSdkWrapper.configure80mm());
+    if (configResult) return configResult;
+
+    const statusResult = ensureReady(await iminSdkWrapper.getStatus());
+    if (statusResult) return statusResult;
+
+    let commands: PrintCommand[];
+    try {
+      commands = buildThermalReceiptCommands(data);
+    } catch {
+      return failedResult("render_failed");
+    }
+
+    for (const command of commands) {
+      const commandStatus = ensureReady(await executeCommand(command));
+      if (commandStatus) return commandStatus;
+    }
+
+    return {
+      success: true,
+      mode: "imin",
+      message: "Comprobante impreso en iMin.",
+    };
+  },
+};
+
+export const isIminPrinterAvailable = (): boolean => iminPrinter.isAvailable();
+
+export const printReceipt = (data: ReceiptPrintData): Promise<PrintResult> =>
+  iminPrinter.printReceipt(data);

--- a/src/printing/printers/imin/imin-sdk-wrapper.ts
+++ b/src/printing/printers/imin/imin-sdk-wrapper.ts
@@ -4,14 +4,38 @@ import type {
   PrintFailureReason,
   PrinterStatus,
 } from "@/printing/types";
+import type {
+  IminMaybeAsync,
+  IminPrintCallback,
+  IminPrintInstance,
+} from "@/printing/printers/imin/types";
 
 const FALCON_80MM_PAGE_FORMAT = 0;
 const FALCON_80MM_TEXT_WIDTH = 576;
+const FALCON_QR_SIZE = 6;
+const FALCON_QR_ERROR_CORRECTION_LEVEL = 48;
+const IMIN_WEBSOCKET_URL = "ws://127.0.0.1:8081/websocket";
+const COMMAND_TIMEOUT_MS = 2_500;
+const CONNECT_TIMEOUT_MS = 1_500;
 
 type TextCommandOptions = Pick<
   Extract<PrintCommand, { type: "text" }>,
   "align" | "bold" | "size"
 >;
+
+type IminTransport = "window-sdk" | "websocket";
+
+type WebSocketConstructor = new (url: string) => WebSocket;
+
+type WebSocketResponse = {
+  id?: number;
+  result?: unknown;
+  data?: unknown;
+  status?: unknown;
+  code?: unknown;
+  error?: unknown;
+  message?: unknown;
+};
 
 const alignmentToSdkValue: Record<PrintAlignment, number> = {
   left: 0,
@@ -66,75 +90,532 @@ export const mapIminStatus = (status?: number): PrinterStatus => {
   };
 };
 
-export class IminSdkWrapper {
+const readyStatus = (message = "Comando iMin ejecutado."): PrinterStatus => ({
+  ready: true,
+  message,
+});
+
+const failedStatus = (
+  reason: PrintFailureReason,
+  message = messageForPrintFailure(reason),
+): PrinterStatus => ({
+  ready: false,
+  reason,
+  message,
+});
+
+const readWindowSdk = (): IminPrintInstance | undefined => {
+  if (typeof window === "undefined") return undefined;
+  return window.IminPrintInstance;
+};
+
+const getWebSocketConstructor = (): WebSocketConstructor | undefined => {
+  const candidate = globalThis.WebSocket;
+  return typeof candidate === "function"
+    ? (candidate as unknown as WebSocketConstructor)
+    : undefined;
+};
+
+const normalizeCallbackValue = (value: unknown): unknown => {
+  if (
+    value &&
+    typeof value === "object" &&
+    "data" in value &&
+    Object.keys(value).length === 1
+  ) {
+    return (value as { data: unknown }).data;
+  }
+
+  return value;
+};
+
+const numericFrom = (value: unknown): number | undefined => {
+  const normalized = normalizeCallbackValue(value);
+
+  if (typeof normalized === "number") return normalized;
+
+  if (typeof normalized === "string") {
+    const parsed = Number(normalized);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  if (!normalized || typeof normalized !== "object") return undefined;
+
+  const objectValue = normalized as Record<string, unknown>;
+  return (
+    numericFrom(objectValue.status) ??
+    numericFrom(objectValue.code) ??
+    numericFrom(objectValue.result) ??
+    numericFrom(objectValue.data)
+  );
+};
+
+const statusFromCommandValue = (value: unknown): PrinterStatus => {
+  const statusCode = numericFrom(value);
+  if (statusCode === undefined || statusCode === 0) return readyStatus();
+  return mapIminStatus(statusCode);
+};
+
+const sdkPromise = async <T>(
+  invoke: (callback: IminPrintCallback<T>) => IminMaybeAsync<T>,
+): Promise<T | undefined> =>
+  new Promise<T | undefined>((resolve, reject) => {
+    let settled = false;
+
+    const settle = (value: T | undefined) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+
+    const callback: IminPrintCallback<T> = (result) => {
+      settle(result);
+    };
+
+    try {
+      const returned = invoke(callback);
+
+      if (returned && typeof (returned as Promise<T>).then === "function") {
+        void (returned as Promise<T>).then(settle, reject);
+        return;
+      }
+
+      if (returned !== undefined) {
+        settle(returned as T);
+        return;
+      }
+
+      window.setTimeout(() => settle(undefined), COMMAND_TIMEOUT_MS);
+    } catch (error) {
+      reject(error);
+    }
+  });
+
+class IminWebSocketClient {
+  private socket?: WebSocket;
+  private connectPromise?: Promise<WebSocket>;
+  private nextRequestId = 1;
+  private pendingRequests = new Map<
+    number,
+    {
+      resolve: (value: unknown) => void;
+      reject: (reason?: unknown) => void;
+      timeout: ReturnType<typeof setTimeout>;
+    }
+  >();
+
+  constructor(
+    private readonly url = IMIN_WEBSOCKET_URL,
+    private readonly WebSocketImpl = getWebSocketConstructor(),
+  ) {}
+
   isAvailable(): boolean {
-    return false;
+    return Boolean(this.WebSocketImpl);
+  }
+
+  disconnect() {
+    this.pendingRequests.forEach((request) => {
+      clearTimeout(request.timeout);
+      request.reject(new Error("iMin websocket disconnected"));
+    });
+    this.pendingRequests.clear();
+
+    this.socket?.close();
+    this.socket = undefined;
+    this.connectPromise = undefined;
+  }
+
+  async command(method: string, params: unknown[] = []): Promise<unknown> {
+    const socket = await this.connect();
+    const id = this.nextRequestId++;
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pendingRequests.delete(id);
+        reject(new Error(`iMin websocket command timed out: ${method}`));
+      }, COMMAND_TIMEOUT_MS);
+
+      this.pendingRequests.set(id, { resolve, reject, timeout });
+
+      socket.send(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id,
+          method,
+          params,
+        }),
+      );
+    });
+  }
+
+  private async connect(): Promise<WebSocket> {
+    if (this.socket?.readyState === 1) return this.socket;
+    if (this.connectPromise) return this.connectPromise;
+
+    if (!this.WebSocketImpl) {
+      throw new Error("WebSocket is not available");
+    }
+
+    const WebSocketImpl = this.WebSocketImpl;
+
+    this.connectPromise = new Promise<WebSocket>((resolve, reject) => {
+      const socket = new WebSocketImpl(this.url);
+      const timeout = setTimeout(() => {
+        cleanup();
+        socket.close();
+        reject(new Error("iMin websocket connection timed out"));
+      }, CONNECT_TIMEOUT_MS);
+
+      const cleanup = () => {
+        clearTimeout(timeout);
+        socket.removeEventListener("open", handleOpen);
+        socket.removeEventListener("error", handleError);
+      };
+
+      const handleOpen = () => {
+        cleanup();
+        this.socket = socket;
+        socket.addEventListener("message", this.handleMessage);
+        socket.addEventListener("close", this.handleClose);
+        socket.addEventListener("error", this.handleClose);
+        resolve(socket);
+      };
+
+      const handleError = () => {
+        cleanup();
+        reject(new Error("iMin websocket connection failed"));
+      };
+
+      socket.addEventListener("open", handleOpen);
+      socket.addEventListener("error", handleError);
+    }).finally(() => {
+      this.connectPromise = undefined;
+    });
+
+    return this.connectPromise;
+  }
+
+  private handleClose = () => {
+    this.socket = undefined;
+    this.pendingRequests.forEach((request) => {
+      clearTimeout(request.timeout);
+      request.reject(new Error("iMin websocket connection closed"));
+    });
+    this.pendingRequests.clear();
+  };
+
+  private handleMessage = (event: MessageEvent) => {
+    const response = this.parseResponse(event.data);
+    if (!response) return;
+
+    const id = typeof response.id === "number" ? response.id : undefined;
+    if (id === undefined) return;
+
+    const request = this.pendingRequests.get(id);
+    if (!request) return;
+
+    clearTimeout(request.timeout);
+    this.pendingRequests.delete(id);
+
+    if (response.error) {
+      request.reject(response.error);
+      return;
+    }
+
+    request.resolve(response.result ?? response.data ?? response.status ?? response.code);
+  };
+
+  private parseResponse(data: unknown): WebSocketResponse | undefined {
+    if (typeof data !== "string") return undefined;
+
+    try {
+      return JSON.parse(data) as WebSocketResponse;
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+export class IminSdkWrapper {
+  private websocketClient?: IminWebSocketClient;
+  private activeTransport?: IminTransport;
+
+  isAvailable(): boolean {
+    return Boolean(readWindowSdk()) || this.getWebSocketClient().isAvailable();
   }
 
   async initialize(): Promise<PrinterStatus> {
-    return {
-      ready: false,
-      reason: "sdk_unavailable",
-      message: messageForPrintFailure("sdk_unavailable"),
-    };
+    const sdk = readWindowSdk();
+    if (sdk) {
+      return this.withWindowSdk(async () => {
+        this.requireSdkMethod(sdk, "initPrinter");
+        await sdkPromise((callback) =>
+          sdk.initPrinter?.(this.connectType(sdk), callback),
+        );
+        this.activeTransport = "window-sdk";
+        return readyStatus("Impresora iMin inicializada.");
+      });
+    }
+
+    return this.withWebSocket(async (client) => {
+      await client.command("initPrinter", [this.connectType()]);
+      this.activeTransport = "websocket";
+      return readyStatus("Impresora iMin inicializada.");
+    });
   }
 
   async configure80mm(): Promise<PrinterStatus> {
-    void FALCON_80MM_PAGE_FORMAT;
-    void FALCON_80MM_TEXT_WIDTH;
+    const sdk = readWindowSdk();
+    if (sdk) {
+      return this.withWindowSdk(async () => {
+        this.requireSdkMethod(sdk, "setPageFormat");
+        this.requireSdkMethod(sdk, "setTextWidth");
+        await sdkPromise((callback) =>
+          sdk.setPageFormat?.(FALCON_80MM_PAGE_FORMAT, callback),
+        );
+        await sdkPromise((callback) =>
+          sdk.setTextWidth?.(FALCON_80MM_TEXT_WIDTH, callback),
+        );
+        return readyStatus("Formato iMin 80mm configurado.");
+      });
+    }
 
-    return {
-      ready: false,
-      reason: "sdk_unavailable",
-      message: messageForPrintFailure("sdk_unavailable"),
-    };
+    return this.withWebSocket(async (client) => {
+      await client.command("setPageFormat", [FALCON_80MM_PAGE_FORMAT]);
+      await client.command("setTextWidth", [FALCON_80MM_TEXT_WIDTH]);
+      return readyStatus("Formato iMin 80mm configurado.");
+    });
   }
 
   async getStatus(): Promise<PrinterStatus> {
-    return {
-      ready: false,
-      reason: "sdk_unavailable",
-      message: messageForPrintFailure("sdk_unavailable"),
-    };
+    const sdk = readWindowSdk();
+    if (sdk) {
+      return this.withWindowSdk(async () => {
+        this.requireSdkMethod(sdk, "getPrinterStatus");
+        const status = await sdkPromise<number>((callback) =>
+          sdk.getPrinterStatus?.(this.connectType(sdk), callback),
+        );
+        return mapIminStatus(numericFrom(status));
+      });
+    }
+
+    return this.withWebSocket(async (client) => {
+      const status = await client.command("getPrinterStatus", [
+        this.connectType(),
+      ]);
+      return mapIminStatus(numericFrom(status));
+    });
   }
 
   async printText(
-    _value: string,
-    _options?: TextCommandOptions,
+    value: string,
+    options?: TextCommandOptions,
   ): Promise<PrinterStatus> {
-    return this.unavailable();
+    const sdk = readWindowSdk();
+    if (sdk) {
+      return this.withWindowSdk(async () => {
+        await this.configureText(sdk, options);
+        this.requireSdkMethod(sdk, "printText");
+        const result = await sdkPromise((callback) =>
+          sdk.printText?.(`${value}\n`, callback),
+        );
+        return statusFromCommandValue(result);
+      });
+    }
+
+    return this.withWebSocket(async (client) => {
+      await client.command("setAlignment", [
+        this.sdkAlignmentFor(options?.align),
+      ]);
+      await client.command("setTextSize", [options?.size ?? 1]);
+      await client.command("setTextStyle", [options?.bold ? 1 : 0]);
+      return statusFromCommandValue(
+        await client.command("printText", [`${value}\n`]),
+      );
+    });
   }
 
   async printColumns(
-    _values: string[],
-    _widths: number[],
-    _aligns: PrintAlignment[],
+    values: string[],
+    widths: number[],
+    aligns: PrintAlignment[],
+    bold = false,
   ): Promise<PrinterStatus> {
-    return this.unavailable();
+    const sdkAligns = aligns.map((align) => this.sdkAlignmentFor(align));
+    const sdk = readWindowSdk();
+    if (sdk) {
+      return this.withWindowSdk(async () => {
+        this.requireSdkMethod(sdk, "setTextStyle");
+        this.requireSdkMethod(sdk, "printColumnsText");
+        await sdkPromise((callback) => sdk.setTextStyle?.(bold ? 1 : 0, callback));
+        const result = await sdkPromise((callback) =>
+          sdk.printColumnsText?.(values, widths, sdkAligns, callback),
+        );
+        return statusFromCommandValue(result);
+      });
+    }
+
+    return this.withWebSocket(async (client) => {
+      await client.command("setTextStyle", [bold ? 1 : 0]);
+      return statusFromCommandValue(
+        await client.command("printColumnsText", [values, widths, sdkAligns]),
+      );
+    });
   }
 
-  async printQr(_value: string): Promise<PrinterStatus> {
-    return this.unavailable();
+  async printQr(value: string): Promise<PrinterStatus> {
+    const sdk = readWindowSdk();
+    if (sdk) {
+      return this.withWindowSdk(async () => {
+        this.requireSdkMethod(sdk, "printQrCode");
+        if (sdk.setQrCodeSize) {
+          await sdkPromise((callback) =>
+            sdk.setQrCodeSize?.(FALCON_QR_SIZE, callback),
+          );
+        }
+        if (sdk.setQrCodeErrorCorrectionLev) {
+          await sdkPromise((callback) =>
+            sdk.setQrCodeErrorCorrectionLev?.(
+              FALCON_QR_ERROR_CORRECTION_LEVEL,
+              callback,
+            ),
+          );
+        }
+        const result = await sdkPromise((callback) =>
+          sdk.printQrCode?.(value, callback),
+        );
+        return statusFromCommandValue(result);
+      });
+    }
+
+    return this.withWebSocket(async (client) => {
+      await client.command("setQrCodeSize", [FALCON_QR_SIZE]);
+      await client.command("setQrCodeErrorCorrectionLev", [
+        FALCON_QR_ERROR_CORRECTION_LEVEL,
+      ]);
+      return statusFromCommandValue(await client.command("printQrCode", [value]));
+    });
   }
 
-  async feed(_lines: number): Promise<PrinterStatus> {
-    return this.unavailable();
+  async feed(lines: number): Promise<PrinterStatus> {
+    const sdk = readWindowSdk();
+    if (sdk) {
+      return this.withWindowSdk(async () => {
+        if (sdk.printAndFeedPaper) {
+          return statusFromCommandValue(
+            await sdkPromise((callback) =>
+              sdk.printAndFeedPaper?.(lines, callback),
+            ),
+          );
+        }
+
+        this.requireSdkMethod(sdk, "printAndLineFeed");
+        for (let index = 0; index < lines; index += 1) {
+          const result = await sdkPromise((callback) =>
+            sdk.printAndLineFeed?.(callback),
+          );
+          const status = statusFromCommandValue(result);
+          if (!status.ready) return status;
+        }
+        return readyStatus();
+      });
+    }
+
+    return this.withWebSocket(async (client) =>
+      statusFromCommandValue(await client.command("printAndFeedPaper", [lines])),
+    );
   }
 
   async cut(): Promise<PrinterStatus> {
-    return this.unavailable();
+    const sdk = readWindowSdk();
+    if (sdk) {
+      return this.withWindowSdk(async () => {
+        const cutMethod = sdk.partialCut ?? sdk.partialCutPaper;
+        if (!cutMethod) return failedStatus("plugin_unavailable");
+        const result = await sdkPromise((callback) => cutMethod.call(sdk, callback));
+        return statusFromCommandValue(result);
+      });
+    }
+
+    return this.withWebSocket(async (client) =>
+      statusFromCommandValue(await client.command("partialCut", [])),
+    );
+  }
+
+  resetConnection() {
+    this.websocketClient?.disconnect();
+    this.websocketClient = undefined;
+    this.activeTransport = undefined;
   }
 
   sdkAlignmentFor(align: PrintAlignment = "left"): number {
     return alignmentToSdkValue[align];
   }
 
-  private unavailable(): PrinterStatus {
-    return {
-      ready: false,
-      reason: "sdk_unavailable",
-      message: messageForPrintFailure("sdk_unavailable"),
-    };
+  getActiveTransport(): IminTransport | undefined {
+    return this.activeTransport;
+  }
+
+  private getWebSocketClient(): IminWebSocketClient {
+    this.websocketClient ??= new IminWebSocketClient();
+    return this.websocketClient;
+  }
+
+  private connectType(sdk?: IminPrintInstance): string | number {
+    return sdk?.PrintConnectType?.USB ?? "USB";
+  }
+
+  private async configureText(
+    sdk: IminPrintInstance,
+    options: TextCommandOptions | undefined,
+  ) {
+    this.requireSdkMethod(sdk, "setAlignment");
+    this.requireSdkMethod(sdk, "setTextSize");
+    this.requireSdkMethod(sdk, "setTextStyle");
+
+    await sdkPromise((callback) =>
+      sdk.setAlignment?.(this.sdkAlignmentFor(options?.align), callback),
+    );
+    await sdkPromise((callback) =>
+      sdk.setTextSize?.(options?.size ?? 1, callback),
+    );
+    await sdkPromise((callback) =>
+      sdk.setTextStyle?.(options?.bold ? 1 : 0, callback),
+    );
+  }
+
+  private requireSdkMethod<K extends keyof IminPrintInstance>(
+    sdk: IminPrintInstance,
+    method: K,
+  ) {
+    if (typeof sdk[method] !== "function") {
+      throw new Error(`iMin SDK method is unavailable: ${String(method)}`);
+    }
+  }
+
+  private async withWindowSdk(
+    action: () => Promise<PrinterStatus>,
+  ): Promise<PrinterStatus> {
+    try {
+      return await action();
+    } catch (error) {
+      console.warn("iMin window SDK command failed", error);
+      return failedStatus("plugin_unavailable");
+    }
+  }
+
+  private async withWebSocket(
+    action: (client: IminWebSocketClient) => Promise<PrinterStatus>,
+  ): Promise<PrinterStatus> {
+    const client = this.getWebSocketClient();
+    if (!client.isAvailable()) return failedStatus("sdk_unavailable");
+
+    try {
+      return await action(client);
+    } catch (error) {
+      console.warn("iMin websocket command failed", error);
+      return failedStatus("plugin_unavailable");
+    }
   }
 }
 

--- a/src/printing/printers/imin/imin-sdk-wrapper.ts
+++ b/src/printing/printers/imin/imin-sdk-wrapper.ts
@@ -1,0 +1,141 @@
+import type {
+  PrintAlignment,
+  PrintCommand,
+  PrintFailureReason,
+  PrinterStatus,
+} from "@/printing/types";
+
+const FALCON_80MM_PAGE_FORMAT = 0;
+const FALCON_80MM_TEXT_WIDTH = 576;
+
+type TextCommandOptions = Pick<
+  Extract<PrintCommand, { type: "text" }>,
+  "align" | "bold" | "size"
+>;
+
+const alignmentToSdkValue: Record<PrintAlignment, number> = {
+  left: 0,
+  center: 1,
+  right: 2,
+};
+
+const printerStatusReason: Record<number, PrintFailureReason> = {
+  [-1]: "printer_not_connected",
+  1: "printer_not_connected",
+  3: "printer_head_open",
+  7: "paper_out",
+  8: "paper_low",
+  99: "printer_unknown_error",
+};
+
+const printerStatusMessage: Record<PrintFailureReason, string> = {
+  sdk_unavailable: "El SDK de iMin no esta disponible en este navegador.",
+  plugin_unavailable: "El plugin de impresion iMin no esta disponible.",
+  printer_not_connected: "La impresora iMin no esta conectada.",
+  printer_head_open: "La tapa de la impresora iMin esta abierta.",
+  paper_out: "La impresora iMin no tiene papel.",
+  paper_low: "La impresora iMin tiene poco papel.",
+  printer_unknown_error: "La impresora iMin reporto un error desconocido.",
+  data_fetch_failed: "No se pudo obtener la informacion para imprimir.",
+  render_failed: "No se pudo preparar el comprobante para impresion termica.",
+  print_failed: "No se pudo imprimir el comprobante en la impresora iMin.",
+};
+
+export const messageForPrintFailure = (reason: PrintFailureReason): string =>
+  printerStatusMessage[reason];
+
+export const mapIminStatus = (status?: number): PrinterStatus => {
+  if (status === 0) {
+    return {
+      code: status,
+      ready: true,
+      message: "La impresora iMin esta lista.",
+    };
+  }
+
+  const reason =
+    typeof status === "number"
+      ? printerStatusReason[status] ?? "printer_unknown_error"
+      : "printer_unknown_error";
+
+  return {
+    code: status,
+    ready: false,
+    reason,
+    message: messageForPrintFailure(reason),
+  };
+};
+
+export class IminSdkWrapper {
+  isAvailable(): boolean {
+    return false;
+  }
+
+  async initialize(): Promise<PrinterStatus> {
+    return {
+      ready: false,
+      reason: "sdk_unavailable",
+      message: messageForPrintFailure("sdk_unavailable"),
+    };
+  }
+
+  async configure80mm(): Promise<PrinterStatus> {
+    void FALCON_80MM_PAGE_FORMAT;
+    void FALCON_80MM_TEXT_WIDTH;
+
+    return {
+      ready: false,
+      reason: "sdk_unavailable",
+      message: messageForPrintFailure("sdk_unavailable"),
+    };
+  }
+
+  async getStatus(): Promise<PrinterStatus> {
+    return {
+      ready: false,
+      reason: "sdk_unavailable",
+      message: messageForPrintFailure("sdk_unavailable"),
+    };
+  }
+
+  async printText(
+    _value: string,
+    _options?: TextCommandOptions,
+  ): Promise<PrinterStatus> {
+    return this.unavailable();
+  }
+
+  async printColumns(
+    _values: string[],
+    _widths: number[],
+    _aligns: PrintAlignment[],
+  ): Promise<PrinterStatus> {
+    return this.unavailable();
+  }
+
+  async printQr(_value: string): Promise<PrinterStatus> {
+    return this.unavailable();
+  }
+
+  async feed(_lines: number): Promise<PrinterStatus> {
+    return this.unavailable();
+  }
+
+  async cut(): Promise<PrinterStatus> {
+    return this.unavailable();
+  }
+
+  sdkAlignmentFor(align: PrintAlignment = "left"): number {
+    return alignmentToSdkValue[align];
+  }
+
+  private unavailable(): PrinterStatus {
+    return {
+      ready: false,
+      reason: "sdk_unavailable",
+      message: messageForPrintFailure("sdk_unavailable"),
+    };
+  }
+}
+
+export const iminSdkWrapper = new IminSdkWrapper();

--- a/src/printing/printers/imin/imin-sdk-wrapper.ts
+++ b/src/printing/printers/imin/imin-sdk-wrapper.ts
@@ -17,6 +17,7 @@ const FALCON_QR_ERROR_CORRECTION_LEVEL = 48;
 const IMIN_WEBSOCKET_URL = "ws://127.0.0.1:8081/websocket";
 const COMMAND_TIMEOUT_MS = 2_500;
 const CONNECT_TIMEOUT_MS = 1_500;
+const IMIN_WEBSOCKET_CONTRACT_LOG_PREFIX = "[iMin WebSocket contract]";
 
 type TextCommandOptions = Pick<
   Extract<PrintCommand, { type: "text" }>,
@@ -33,6 +34,7 @@ type WebSocketResponse = {
   data?: unknown;
   status?: unknown;
   code?: unknown;
+  value?: unknown;
   error?: unknown;
   message?: unknown;
 };
@@ -143,6 +145,7 @@ const numericFrom = (value: unknown): number | undefined => {
 
   const objectValue = normalized as Record<string, unknown>;
   return (
+    numericFrom(objectValue.value) ??
     numericFrom(objectValue.status) ??
     numericFrom(objectValue.code) ??
     numericFrom(objectValue.result) ??
@@ -152,7 +155,27 @@ const numericFrom = (value: unknown): number | undefined => {
 
 const statusFromCommandValue = (value: unknown): PrinterStatus => {
   const statusCode = numericFrom(value);
-  if (statusCode === undefined || statusCode === 0) return readyStatus();
+  if (statusCode === undefined) {
+    if (value !== undefined) {
+      console.warn(
+        `${IMIN_WEBSOCKET_CONTRACT_LOG_PREFIX} Command response did not include a numeric status code.`,
+        {
+          response: value,
+          expectedShapes: [
+            0,
+            { value: 0 },
+            { result: { value: 0 } },
+            { data: { value: 0 } },
+            { status: { value: 0 } },
+          ],
+        },
+      );
+    }
+
+    return readyStatus();
+  }
+
+  if (statusCode === 0) return readyStatus();
   return mapIminStatus(statusCode);
 };
 
@@ -201,6 +224,8 @@ class IminWebSocketClient {
       resolve: (value: unknown) => void;
       reject: (reason?: unknown) => void;
       timeout: ReturnType<typeof setTimeout>;
+      method: string;
+      params: unknown[];
     }
   >();
 
@@ -228,23 +253,34 @@ class IminWebSocketClient {
   async command(method: string, params: unknown[] = []): Promise<unknown> {
     const socket = await this.connect();
     const id = this.nextRequestId++;
+    const payload = {
+      jsonrpc: "2.0",
+      id,
+      method,
+      params,
+    };
 
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.pendingRequests.delete(id);
+        console.warn(
+          `${IMIN_WEBSOCKET_CONTRACT_LOG_PREFIX} Command timed out waiting for a response with matching id.`,
+          {
+            request: payload,
+            expectedResponseShapes: [
+              { id, result: { value: 0 } },
+              { id, data: { value: 0 } },
+              { id, status: { value: 0 } },
+              { id, value: 0 },
+            ],
+          },
+        );
         reject(new Error(`iMin websocket command timed out: ${method}`));
       }, COMMAND_TIMEOUT_MS);
 
-      this.pendingRequests.set(id, { resolve, reject, timeout });
+      this.pendingRequests.set(id, { resolve, reject, timeout, method, params });
 
-      socket.send(
-        JSON.stringify({
-          jsonrpc: "2.0",
-          id,
-          method,
-          params,
-        }),
-      );
+      socket.send(JSON.stringify(payload));
     });
   }
 
@@ -306,23 +342,69 @@ class IminWebSocketClient {
 
   private handleMessage = (event: MessageEvent) => {
     const response = this.parseResponse(event.data);
-    if (!response) return;
+    if (!response) {
+      console.warn(
+        `${IMIN_WEBSOCKET_CONTRACT_LOG_PREFIX} Received a non-JSON or unsupported response.`,
+        {
+          rawResponse: event.data,
+        },
+      );
+      return;
+    }
 
     const id = typeof response.id === "number" ? response.id : undefined;
-    if (id === undefined) return;
+    if (id === undefined) {
+      console.warn(
+        `${IMIN_WEBSOCKET_CONTRACT_LOG_PREFIX} Received a response without numeric id.`,
+        {
+          response,
+          pendingRequests: Array.from(this.pendingRequests.values()).map(
+            ({ method, params }) => ({ method, params }),
+          ),
+        },
+      );
+      return;
+    }
 
     const request = this.pendingRequests.get(id);
-    if (!request) return;
+    if (!request) {
+      console.warn(
+        `${IMIN_WEBSOCKET_CONTRACT_LOG_PREFIX} Received a response for an unknown id.`,
+        {
+          response,
+          pendingRequestIds: Array.from(this.pendingRequests.keys()),
+        },
+      );
+      return;
+    }
 
     clearTimeout(request.timeout);
     this.pendingRequests.delete(id);
 
     if (response.error) {
+      console.warn(
+        `${IMIN_WEBSOCKET_CONTRACT_LOG_PREFIX} Service returned an error response.`,
+        {
+          request: {
+            id,
+            method: request.method,
+            params: request.params,
+          },
+          response,
+        },
+      );
       request.reject(response.error);
       return;
     }
 
-    request.resolve(response.result ?? response.data ?? response.status ?? response.code);
+    request.resolve(
+      response.result ??
+        response.data ??
+        response.status ??
+        response.code ??
+        response.value ??
+        response,
+    );
   };
 
   private parseResponse(data: unknown): WebSocketResponse | undefined {
@@ -341,7 +423,7 @@ export class IminSdkWrapper {
   private activeTransport?: IminTransport;
 
   isAvailable(): boolean {
-    return Boolean(readWindowSdk()) || this.getWebSocketClient().isAvailable();
+    return Boolean(readWindowSdk()) || this.activeTransport === "websocket";
   }
 
   async initialize(): Promise<PrinterStatus> {
@@ -458,7 +540,13 @@ export class IminSdkWrapper {
     return this.withWebSocket(async (client) => {
       await client.command("setTextStyle", [bold ? 1 : 0]);
       return statusFromCommandValue(
-        await client.command("printColumnsText", [values, widths, sdkAligns]),
+        await client.command("printColumnsText", [
+          values,
+          widths,
+          sdkAligns,
+          FALCON_80MM_TEXT_WIDTH,
+          1,
+        ]),
       );
     });
   }

--- a/src/printing/printers/imin/thermal-receipt-renderer.ts
+++ b/src/printing/printers/imin/thermal-receipt-renderer.ts
@@ -1,0 +1,316 @@
+import { INVOICE, RECEIPT, TICKET, type DocumentType } from "@/document/types";
+import {
+  billableNumberToWords,
+  formatPriceWithoutCurrency,
+  paymentMethodToText,
+  shortLocalizeDate,
+} from "@/lib/utils";
+import type {
+  PrintAlignment,
+  PrintCommand,
+  ReceiptPrintData,
+} from "@/printing/types";
+import { UNIT_TYPE_MAPPER } from "@/product/constants";
+
+const COLUMNS = 48;
+const ITEM_NAME_WIDTH = 24;
+
+const documentTypeToText: Record<DocumentType, string> = {
+  [INVOICE]: "FACTURA ELECTRONICA",
+  [RECEIPT]: "BOLETA ELECTRONICA",
+  [TICKET]: "NOTA DE VENTA ELECTRONICA",
+};
+
+const customerDocumentTypeToText: Record<string, string> = {
+  dni: "DNI",
+  ruc: "RUC",
+  carnet_extranjeria: "Carnet de extranjeria",
+};
+
+const text = (
+  value: string,
+  options: Omit<Extract<PrintCommand, { type: "text" }>, "type" | "value"> = {},
+): PrintCommand => ({
+  type: "text",
+  value,
+  ...options,
+});
+
+const columns = (
+  values: string[],
+  widths: number[],
+  aligns: PrintAlignment[],
+  bold?: boolean,
+): PrintCommand => ({
+  type: "columns",
+  values,
+  widths,
+  aligns,
+  bold,
+});
+
+const separator = (char = "-") => text(char.repeat(COLUMNS));
+
+const clean = (value: string | number | undefined | null): string =>
+  String(value ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const money = (value: number): string => formatPriceWithoutCurrency(value);
+
+const formatDate = (value: string): string => shortLocalizeDate(new Date(value));
+
+const chunkText = (value: string, width: number): string[] => {
+  const words = clean(value).split(" ").filter(Boolean);
+  const lines: string[] = [];
+  let current = "";
+
+  words.forEach((word) => {
+    if (!current) {
+      current = word;
+      return;
+    }
+
+    if (`${current} ${word}`.length <= width) {
+      current = `${current} ${word}`;
+      return;
+    }
+
+    lines.push(current);
+    current = word;
+  });
+
+  if (current) {
+    lines.push(current);
+  }
+
+  return lines.flatMap((line) => {
+    if (line.length <= width) return [line];
+
+    const chunks: string[] = [];
+    for (let index = 0; index < line.length; index += width) {
+      chunks.push(line.slice(index, index + width));
+    }
+    return chunks;
+  });
+};
+
+const pushWrappedLabel = (
+  commands: PrintCommand[],
+  label: string,
+  value: string | undefined,
+) => {
+  if (!value) return;
+
+  chunkText(`${label}: ${value}`, COLUMNS).forEach((line) => {
+    commands.push(text(line));
+  });
+};
+
+const addHeader = (commands: PrintCommand[], data: ReceiptPrintData) => {
+  const { company, document } = data;
+
+  commands.push(text(clean(company.commercialName || company.legalName), {
+    align: "center",
+    bold: true,
+    size: 2,
+  }));
+
+  if (company.legalName && company.legalName !== company.commercialName) {
+    commands.push(text(clean(company.legalName), { align: "center" }));
+  }
+
+  pushWrappedLabel(commands, "RUC", company.ruc);
+  pushWrappedLabel(commands, "Direccion", company.address);
+  pushWrappedLabel(commands, "Ubicacion", company.location);
+  pushWrappedLabel(commands, "Email", company.email);
+  pushWrappedLabel(commands, "Telefono", company.phone);
+
+  commands.push(separator("="));
+  commands.push(text(documentTypeToText[document.type], {
+    align: "center",
+    bold: true,
+  }));
+  commands.push(text(document.correlative, { align: "center", bold: true }));
+  commands.push(separator("="));
+};
+
+const addDocumentData = (commands: PrintCommand[], data: ReceiptPrintData) => {
+  const { customer, document, order } = data;
+  const customerDocumentLabel = customer?.documentType
+    ? customerDocumentTypeToText[customer.documentType] ?? customer.documentType
+    : document.type === INVOICE
+      ? "RUC"
+      : "DNI";
+
+  pushWrappedLabel(commands, "F. Emision", formatDate(document.dateOfIssue));
+
+  if (document.issuedAt) {
+    pushWrappedLabel(commands, "F. Envio", formatDate(document.issuedAt));
+  }
+
+  pushWrappedLabel(commands, "Pedido", order.id);
+  pushWrappedLabel(commands, "Cliente", customer?.name || "Cliente varios");
+  pushWrappedLabel(commands, customerDocumentLabel, customer?.documentNumber);
+  pushWrappedLabel(commands, "Direccion", customer?.address);
+  pushWrappedLabel(commands, "Email", customer?.email);
+  pushWrappedLabel(commands, "Telefono", customer?.phone);
+
+  if (document.status === "cancelled") {
+    commands.push(text("DOCUMENTO ANULADO", { align: "center", bold: true }));
+    pushWrappedLabel(commands, "Motivo", document.cancellationReason);
+  }
+};
+
+const addItems = (commands: PrintCommand[], data: ReceiptPrintData) => {
+  commands.push(separator());
+  commands.push(
+    columns(
+      ["Cant", "Producto", "P.Unit", "Total"],
+      [6, 24, 8, 10],
+      ["left", "left", "right", "right"],
+      true,
+    ),
+  );
+  commands.push(separator());
+
+  data.order.items.forEach((item) => {
+    const quantity = `${item.quantity} ${UNIT_TYPE_MAPPER[item.unitType]}`;
+    const productLines = chunkText(item.name, ITEM_NAME_WIDTH);
+    const [firstLine = ""] = productLines;
+
+    commands.push(
+      columns(
+        [quantity, firstLine, money(item.unitPrice), money(item.netTotal)],
+        [6, 24, 8, 10],
+        ["left", "left", "right", "right"],
+      ),
+    );
+
+    productLines.slice(1).forEach((line) => {
+      commands.push(
+        columns(
+          ["", line, "", ""],
+          [6, 24, 8, 10],
+          ["left", "left", "right", "right"],
+        ),
+      );
+    });
+
+    if (item.discountAmount > 0) {
+      commands.push(
+        columns(
+          ["", "Descuento", "", `-${money(item.discountAmount)}`],
+          [6, 24, 8, 10],
+          ["left", "left", "right", "right"],
+        ),
+      );
+    }
+  });
+};
+
+const addTotals = (commands: PrintCommand[], data: ReceiptPrintData) => {
+  commands.push(separator());
+
+  if (data.order.discount > 0) {
+    commands.push(
+      columns(
+        ["Subtotal", money(data.order.subtotal)],
+        [34, 14],
+        ["right", "right"],
+      ),
+    );
+    commands.push(
+      columns(
+        ["Descuento", `-${money(data.order.discount)}`],
+        [34, 14],
+        ["right", "right"],
+      ),
+    );
+  }
+
+  commands.push(
+    columns(
+      ["TOTAL S/", money(data.order.total)],
+      [34, 14],
+      ["right", "right"],
+      true,
+    ),
+  );
+
+  chunkText(`Son: ${billableNumberToWords(data.order.total)}`, COLUMNS).forEach(
+    (line) => commands.push(text(line)),
+  );
+};
+
+const addPayments = (commands: PrintCommand[], data: ReceiptPrintData) => {
+  if (!data.order.payments.length) return;
+
+  commands.push(separator());
+  commands.push(text("Pagos", { bold: true }));
+
+  data.order.payments.forEach((payment) => {
+    const label =
+      payment.method === "wallet" && payment.walletName
+        ? `${paymentMethodToText(payment.method)} ${payment.walletName}`
+        : paymentMethodToText(payment.method);
+
+    commands.push(
+      columns([label, money(payment.amount)], [34, 14], ["left", "right"]),
+    );
+
+    pushWrappedLabel(commands, "Operacion", payment.operationCode);
+
+    if (payment.receivedAmount !== undefined) {
+      commands.push(
+        columns(
+          ["Recibido", money(payment.receivedAmount)],
+          [34, 14],
+          ["left", "right"],
+        ),
+      );
+    }
+
+    if (payment.change !== undefined && payment.change > 0) {
+      commands.push(
+        columns(["Vuelto", money(payment.change)], [34, 14], [
+          "left",
+          "right",
+        ]),
+      );
+    }
+  });
+};
+
+const addFooter = (commands: PrintCommand[], data: ReceiptPrintData) => {
+  if (data.document.hash) {
+    commands.push(separator());
+    commands.push(text("Codigo hash:", { bold: true }));
+    chunkText(data.document.hash, COLUMNS).forEach((line) => {
+      commands.push(text(line));
+    });
+  }
+
+  if (data.document.qr) {
+    commands.push({ type: "qr", value: data.document.qr });
+  }
+
+  commands.push(text("Gracias por su compra", { align: "center" }));
+  commands.push({ type: "feed", lines: 4 });
+  commands.push({ type: "cut" });
+};
+
+export const buildThermalReceiptCommands = (
+  data: ReceiptPrintData,
+): PrintCommand[] => {
+  const commands: PrintCommand[] = [];
+
+  addHeader(commands, data);
+  addDocumentData(commands, data);
+  addItems(commands, data);
+  addTotals(commands, data);
+  addPayments(commands, data);
+  addFooter(commands, data);
+
+  return commands;
+};

--- a/src/printing/printers/imin/types.ts
+++ b/src/printing/printers/imin/types.ts
@@ -1,0 +1,76 @@
+export type IminPrintConnectType = {
+  USB?: string | number;
+  BLUETOOTH?: string | number;
+  SPI?: string | number;
+  SERIAL?: string | number;
+};
+
+export type IminPrintCallback<T = unknown> = (result: T) => void;
+
+export type IminMaybeAsync<T = unknown> = Promise<T> | T | void;
+
+export type IminPrintInstance = {
+  PrintConnectType?: IminPrintConnectType;
+  initPrinter?: (
+    connectType?: string | number,
+    callback?: IminPrintCallback,
+  ) => IminMaybeAsync;
+  getPrinterStatus?: (
+    connectType?: string | number,
+    callback?: IminPrintCallback<number>,
+  ) => IminMaybeAsync<number>;
+  setPageFormat?: (
+    format: number,
+    callback?: IminPrintCallback,
+  ) => IminMaybeAsync;
+  setTextWidth?: (
+    width: number,
+    callback?: IminPrintCallback,
+  ) => IminMaybeAsync;
+  setAlignment?: (
+    alignment: number,
+    callback?: IminPrintCallback,
+  ) => IminMaybeAsync;
+  setTextSize?: (
+    size: number,
+    callback?: IminPrintCallback,
+  ) => IminMaybeAsync;
+  setTextStyle?: (
+    style: number,
+    callback?: IminPrintCallback,
+  ) => IminMaybeAsync;
+  printText?: (text: string, callback?: IminPrintCallback) => IminMaybeAsync;
+  printColumnsText?: (
+    values: string[],
+    widths: number[],
+    aligns: number[],
+    callback?: IminPrintCallback,
+  ) => IminMaybeAsync;
+  setQrCodeSize?: (
+    size: number,
+    callback?: IminPrintCallback,
+  ) => IminMaybeAsync;
+  setQrCodeErrorCorrectionLev?: (
+    level: number,
+    callback?: IminPrintCallback,
+  ) => IminMaybeAsync;
+  printQrCode?: (
+    value: string,
+    callback?: IminPrintCallback,
+  ) => IminMaybeAsync;
+  printAndLineFeed?: (callback?: IminPrintCallback) => IminMaybeAsync;
+  printAndFeedPaper?: (
+    lines: number,
+    callback?: IminPrintCallback,
+  ) => IminMaybeAsync;
+  partialCut?: (callback?: IminPrintCallback) => IminMaybeAsync;
+  partialCutPaper?: (callback?: IminPrintCallback) => IminMaybeAsync;
+};
+
+declare global {
+  interface Window {
+    IminPrintInstance?: IminPrintInstance;
+  }
+}
+
+export {};

--- a/src/printing/printers/imin/types.ts
+++ b/src/printing/printers/imin/types.ts
@@ -9,6 +9,23 @@ export type IminPrintCallback<T = unknown> = (result: T) => void;
 
 export type IminMaybeAsync<T = unknown> = Promise<T> | T | void;
 
+export type IminPrintColumnsText = {
+  (
+    values: string[],
+    widths: number[],
+    aligns: number[],
+    callback?: IminPrintCallback,
+  ): IminMaybeAsync;
+  (
+    values: string[],
+    widths: number[],
+    aligns: number[],
+    width: number,
+    size: number,
+    callback?: IminPrintCallback,
+  ): IminMaybeAsync;
+};
+
 export type IminPrintInstance = {
   PrintConnectType?: IminPrintConnectType;
   initPrinter?: (
@@ -40,12 +57,7 @@ export type IminPrintInstance = {
     callback?: IminPrintCallback,
   ) => IminMaybeAsync;
   printText?: (text: string, callback?: IminPrintCallback) => IminMaybeAsync;
-  printColumnsText?: (
-    values: string[],
-    widths: number[],
-    aligns: number[],
-    callback?: IminPrintCallback,
-  ) => IminMaybeAsync;
+  printColumnsText?: IminPrintColumnsText;
   setQrCodeSize?: (
     size: number,
     callback?: IminPrintCallback,

--- a/src/printing/printing-provider.tsx
+++ b/src/printing/printing-provider.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+
+import { initializePrintingRuntime } from "@/printing/printing-runtime";
+
+export function PrintingProvider({ children }: { children: ReactNode }) {
+  useEffect(() => {
+    void initializePrintingRuntime().catch((error) => {
+      console.warn("Printing runtime initialization failed", error);
+    });
+  }, []);
+
+  return children;
+}

--- a/src/printing/printing-runtime.ts
+++ b/src/printing/printing-runtime.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { initPrinters } from "@/printing/init-printers";
+import type { PrintersInitializationResult } from "@/printing/types";
+
+export type PrintingRuntimeStatus = "initializing" | "ready" | "disabled";
+
+type PrintingRuntimeState = {
+  status: PrintingRuntimeStatus;
+  result?: PrintersInitializationResult;
+};
+
+let runtimeState: PrintingRuntimeState = {
+  status: "initializing",
+};
+let runtimePromise: Promise<PrintersInitializationResult> | undefined;
+
+const statusFromResult = (
+  result: PrintersInitializationResult,
+): PrintingRuntimeStatus => (result.printers.imin.ready ? "ready" : "disabled");
+
+export const initializePrintingRuntime =
+  async (): Promise<PrintersInitializationResult> => {
+    if (runtimeState.result) return runtimeState.result;
+    if (runtimePromise) return runtimePromise;
+
+    runtimeState = {
+      ...runtimeState,
+      status: "initializing",
+    };
+
+    runtimePromise = initPrinters()
+      .then((result) => {
+        runtimeState = {
+          status: statusFromResult(result),
+          result,
+        };
+        return result;
+      })
+      .catch(() => {
+        const result: PrintersInitializationResult = {
+          initializedAt: new Date().toISOString(),
+          printers: {
+            imin: {
+              id: "imin",
+              status: "unavailable",
+              ready: false,
+              reason: "plugin_unavailable",
+              message: "No se pudo inicializar la impresora iMin.",
+            },
+          },
+        };
+
+        runtimeState = {
+          status: "disabled",
+          result,
+        };
+        return result;
+      })
+      .finally(() => {
+        runtimePromise = undefined;
+      });
+
+    return runtimePromise;
+  };
+
+export const isFalconPrintingEnabled = (): boolean =>
+  runtimeState.status === "ready";
+
+export const waitForPrinterInitialization = async (): Promise<boolean> => {
+  if (runtimeState.status === "ready") return true;
+  if (runtimeState.status === "disabled") return false;
+
+  try {
+    const result = await initializePrintingRuntime();
+    return result.printers.imin.ready;
+  } catch {
+    return false;
+  }
+};
+
+export const getPrintingRuntimeState = (): PrintingRuntimeState => ({
+  ...runtimeState,
+});

--- a/src/printing/printing-runtime.ts
+++ b/src/printing/printing-runtime.ts
@@ -21,7 +21,7 @@ const statusFromResult = (
 
 export const initializePrintingRuntime =
   async (): Promise<PrintersInitializationResult> => {
-    if (runtimeState.result) return runtimeState.result;
+    if (runtimeState.result?.printers.imin.ready) return runtimeState.result;
     if (runtimePromise) return runtimePromise;
 
     runtimeState = {
@@ -69,7 +69,6 @@ export const isFalconPrintingEnabled = (): boolean =>
 
 export const waitForPrinterInitialization = async (): Promise<boolean> => {
   if (runtimeState.status === "ready") return true;
-  if (runtimeState.status === "disabled") return false;
 
   try {
     const result = await initializePrintingRuntime();

--- a/src/printing/receipt-builder.ts
+++ b/src/printing/receipt-builder.ts
@@ -1,0 +1,133 @@
+import type { Company } from "@/company/types";
+import {
+  fullName,
+  isBusinessCustomer,
+  isNaturalCustomer,
+} from "@/customer/utils";
+import type { Document } from "@/document/types";
+import { correlative, isBillableDocument } from "@/document/utils";
+import type { Order, Payment } from "@/order/types";
+import type { ReceiptPrintData } from "@/printing/types";
+
+type BuildReceiptPrintDataParams = {
+  order: Order;
+  company: Company;
+  document: Document;
+};
+
+const toIsoString = (date: Date | string | undefined): string | undefined => {
+  if (!date) return undefined;
+  if (typeof date === "string") return date;
+  return date.toISOString();
+};
+
+const buildCustomer = (
+  customer: Order["customer"],
+): ReceiptPrintData["customer"] => {
+  if (!customer) return undefined;
+
+  return {
+    name: fullName(customer),
+    documentType: customer.documentType,
+    documentNumber: customer.documentNumber,
+    address: customer.address,
+    email:
+      isBusinessCustomer(customer) || isNaturalCustomer(customer)
+        ? customer.email
+        : undefined,
+    phone:
+      isBusinessCustomer(customer) || isNaturalCustomer(customer)
+        ? customer.phoneNumber
+        : undefined,
+  };
+};
+
+const buildPayment = (
+  payment: Payment,
+): ReceiptPrintData["order"]["payments"][number] => {
+  if (payment.method === "cash") {
+    return {
+      id: payment.id,
+      method: payment.method,
+      amount: payment.amount,
+      receivedAmount: payment.received_amount,
+      change: payment.change,
+    };
+  }
+
+  if (payment.method === "wallet") {
+    return {
+      id: payment.id,
+      method: payment.method,
+      amount: payment.amount,
+      operationCode: payment.operationCode,
+      walletName: payment.name,
+    };
+  }
+
+  return {
+    id: payment.id,
+    method: payment.method,
+    amount: payment.amount,
+  };
+};
+
+export const buildReceiptPrintData = ({
+  order,
+  company,
+  document,
+}: BuildReceiptPrintDataParams): ReceiptPrintData => ({
+  company: {
+    commercialName: company.subName,
+    legalName: company.name,
+    ruc: company.ruc,
+    address: company.address,
+    location: [company.district, company.provincial, company.department]
+      .filter(Boolean)
+      .join("-"),
+    email: company.email,
+    phone: company.phone,
+    logoUrl: company.logo?.url,
+  },
+  document: {
+    type: document.documentType,
+    series: document.series,
+    number: document.number,
+    correlative: correlative(document),
+    dateOfIssue: toIsoString(document.dateOfIssue)!,
+    status: document.status,
+    cancellationReason:
+      document.status === "cancelled" ? document.cancellationReason : undefined,
+    qr: isBillableDocument(document) ? document.qr : undefined,
+    hash: isBillableDocument(document) ? document.hash : undefined,
+    xml: isBillableDocument(document) ? document.xml : undefined,
+    issuedToTaxEntity: document.issuedToTaxEntity,
+    issuedAt: toIsoString(document.issuedAt),
+  },
+  customer: buildCustomer(order.customer),
+  order: {
+    id: order.id!,
+    date: toIsoString(order.createdAt)!,
+    items: order.orderItems.map((item) => ({
+      id: item.id,
+      productId: item.productId,
+      sku: item.productSku,
+      name: item.productName,
+      quantity: item.quantity,
+      unitType: item.unitType,
+      unitPrice: item.productPrice,
+      netTotal: item.netTotal,
+      discountAmount: item.discountAmount,
+      total: item.total,
+    })),
+    payments: order.payments.map(buildPayment),
+    subtotal: order.netTotal,
+    discount: order.discountAmount,
+    total: order.total,
+  },
+  paper: {
+    widthMm: 80,
+    columns: 48,
+  },
+  fallbackPdfUrl: `/api/orders/${order.id}/documents`,
+});

--- a/src/printing/types.ts
+++ b/src/printing/types.ts
@@ -1,0 +1,148 @@
+import type { CustomerDocumentType } from "@/customer/types";
+import type { DocumentStatus, DocumentType } from "@/document/types";
+import type { PaymentMethod } from "@/order/types";
+import type { KG_UNIT_TYPE, UNIT_UNIT_TYPE } from "@/product/types";
+
+type UnitType = typeof KG_UNIT_TYPE | typeof UNIT_UNIT_TYPE;
+
+export type PrintFailureReason =
+  | "sdk_unavailable"
+  | "plugin_unavailable"
+  | "printer_not_connected"
+  | "printer_head_open"
+  | "paper_out"
+  | "paper_low"
+  | "printer_unknown_error"
+  | "data_fetch_failed"
+  | "render_failed"
+  | "print_failed";
+
+export type PrintMode = "imin" | "pdf";
+
+export type PrintResult =
+  | {
+      success: true;
+      mode: "imin";
+      message?: string;
+    }
+  | {
+      success: true;
+      mode: "pdf";
+      fallbackReason?: PrintFailureReason;
+      message: string;
+    }
+  | {
+      success: false;
+      mode: PrintMode;
+      reason: PrintFailureReason;
+      message: string;
+    };
+
+export type PrinterAdapter = {
+  isAvailable: () => boolean;
+  printReceipt: (data: ReceiptPrintData) => Promise<PrintResult>;
+};
+
+export type PrintAlignment = "left" | "center" | "right";
+
+export type PrinterStatus = {
+  code?: number;
+  ready: boolean;
+  reason?: PrintFailureReason;
+  message: string;
+};
+
+export type PrintCommand =
+  | {
+      type: "text";
+      value: string;
+      align?: PrintAlignment;
+      size?: number;
+      bold?: boolean;
+    }
+  | {
+      type: "columns";
+      values: string[];
+      widths: number[];
+      aligns: PrintAlignment[];
+      bold?: boolean;
+    }
+  | {
+      type: "qr";
+      value: string;
+    }
+  | {
+      type: "feed";
+      lines: number;
+    }
+  | {
+      type: "cut";
+    };
+
+export type ReceiptPrintData = {
+  company: {
+    commercialName?: string;
+    legalName?: string;
+    ruc?: string;
+    address?: string;
+    location?: string;
+    email?: string;
+    phone?: string;
+    logoUrl?: string;
+  };
+  document: {
+    type: DocumentType;
+    series: string;
+    number: string;
+    correlative: string;
+    dateOfIssue: string;
+    status: DocumentStatus;
+    cancellationReason?: string;
+    qr?: string;
+    hash?: string;
+    xml?: string;
+    issuedToTaxEntity?: boolean;
+    issuedAt?: string;
+  };
+  customer?: {
+    name: string;
+    documentType?: CustomerDocumentType;
+    documentNumber?: string;
+    address?: string;
+    email?: string;
+    phone?: string;
+  };
+  order: {
+    id: string;
+    date: string;
+    items: Array<{
+      id: string;
+      productId: string;
+      sku?: string;
+      name: string;
+      quantity: number;
+      unitType: UnitType;
+      unitPrice: number;
+      netTotal: number;
+      discountAmount: number;
+      total: number;
+    }>;
+    payments: Array<{
+      id?: string;
+      method: PaymentMethod;
+      amount: number;
+      operationCode?: string;
+      walletName?: string;
+      receivedAmount?: number;
+      change?: number;
+    }>;
+    subtotal: number;
+    discount: number;
+    total: number;
+  };
+  paper: {
+    widthMm: 80;
+    columns: 48;
+  };
+  fallbackPdfUrl: string;
+};

--- a/src/printing/types.ts
+++ b/src/printing/types.ts
@@ -19,6 +19,10 @@ export type PrintFailureReason =
 
 export type PrintMode = "imin" | "pdf";
 
+export type PrinterId = "imin";
+
+export type PrinterInitializationStatus = "ready" | "unavailable" | "error";
+
 export type PrintResult =
   | {
       success: true;
@@ -40,6 +44,8 @@ export type PrintResult =
 
 export type PrinterAdapter = {
   isAvailable: () => boolean;
+  initialize?: () => Promise<PrinterStatus>;
+  getStatus?: () => Promise<PrinterStatus>;
   printReceipt: (data: ReceiptPrintData) => Promise<PrintResult>;
 };
 
@@ -50,6 +56,19 @@ export type PrinterStatus = {
   ready: boolean;
   reason?: PrintFailureReason;
   message: string;
+};
+
+export type PrinterHealth = {
+  id: PrinterId;
+  status: PrinterInitializationStatus;
+  ready: boolean;
+  reason?: PrintFailureReason;
+  message: string;
+};
+
+export type PrintersInitializationResult = {
+  initializedAt: string;
+  printers: Record<PrinterId, PrinterHealth>;
 };
 
 export type PrintCommand =


### PR DESCRIPTION
## Summary
- add iMin receipt print data and thermal receipt rendering flow
- connect the iMin printer plugin/runtime with PDF fallback
- improve Falcon 1 WebSocket compatibility for column printing and response parsing
- avoid caching failed printer initialization so hardware/service issues can be retried
- add WebSocket contract diagnostics for Falcon 1 validation

## Branch hygiene
- created from origin/main
- includes only printing commits:
  - 730bc8d feat: add imin receipt print fallback flow
  - 66f0daf feat: connect imin printer plugin
  - 3497a90 fix: initialize printing runtime
  - 817861d fix: improve imin websocket printing
- excludes carnet de extranjeria commits

## Validation
- npx eslint src/printing src/order/components/order-print-button.tsx src/new-order/components/create-order-modal/payment-modal.tsx 'src/app/api/orders/[id]/print-data/route.ts'
- npm run build:dev

## Manual validation needed
- Falcon 1 thermal print with active WebSocket service
- physical error fallback: no paper, lid open, service stopped, printer unavailable
- confirm WebSocket response contract and printColumnsText parameter shape