### PR TITLE
fix: preserve company on consecutive product creation

### DIFF
--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -20,8 +20,12 @@ export const POST = protectedRoute(
   { resource: "products", action: "create" },
   async (req, user) => {
     const data: Product = await req.json();
+    const product: Product = {
+      ...data,
+      companyId: user.companyId,
+    };
 
-    const response = await productCreator({ create, findBy }, data);
+    const response = await productCreator({ create, findBy }, product);
     if (response.success) {
       revalidatePath("/api/products");
     }

--- a/src/product/__TEST__/create-product-route.test.ts
+++ b/src/product/__TEST__/create-product-route.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  SingleProductType,
+  UNIT_UNIT_TYPE,
+  type Product,
+} from "@/product/types";
+
+const testContext = vi.hoisted(() => ({
+  create: vi.fn(),
+  findBy: vi.fn(),
+  getMany: vi.fn(),
+  revalidatePath: vi.fn(),
+  user: {
+    id: "user-1",
+    name: "Test User",
+    email: "user@example.com",
+    companyId: "session-company",
+    role: "ADMIN",
+    active: true,
+  },
+}));
+
+vi.mock("@/product/db_repository", () => ({
+  create: testContext.create,
+  findBy: testContext.findBy,
+  getMany: testContext.getMany,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: testContext.revalidatePath,
+}));
+
+vi.mock("@/authorization/server", () => ({
+  protectedRoute:
+    (
+      _guard: unknown,
+      handler: (request: Request, user: typeof testContext.user) => Promise<Response>,
+    ) =>
+    (request: Request) =>
+      handler(request, testContext.user),
+}));
+
+import { POST } from "@/app/api/products/route";
+
+const createSingleProduct = (
+  companyId: string,
+  sku?: string,
+): Product => ({
+  companyId,
+  type: SingleProductType,
+  sku,
+  name: "Producto de prueba",
+  price: 10,
+  purchasePrice: 5,
+  unitType: UNIT_UNIT_TYPE,
+  stock: 2,
+  description: "Descripción",
+  photos: [],
+  categories: [],
+  hidden: false,
+});
+
+const postProduct = (product: Product) =>
+  POST(
+    new Request("http://localhost/api/products", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(product),
+    }),
+  );
+
+describe("POST /api/products", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    testContext.findBy.mockResolvedValue({
+      success: false,
+      message: "Producto no encontrado",
+    });
+    testContext.create.mockImplementation(async (product: Product) => ({
+      success: true,
+      data: {
+        ...product,
+        id: `product-${testContext.create.mock.calls.length}`,
+      },
+    }));
+  });
+
+  test("uses the authenticated company for two consecutive creations", async () => {
+    const firstResponse = await postProduct(
+      createSingleProduct("client-company"),
+    );
+    const secondResponse = await postProduct(createSingleProduct(""));
+
+    expect(firstResponse.status).toBe(201);
+    expect(secondResponse.status).toBe(201);
+    expect(testContext.create).toHaveBeenCalledTimes(2);
+    expect(testContext.create).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ companyId: testContext.user.companyId }),
+    );
+    expect(testContext.create).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ companyId: testContext.user.companyId }),
+    );
+  });
+
+  for (const companyId of ["", "another-company"]) {
+    test(`replaces companyId ${JSON.stringify(companyId)} before SKU lookup and persistence`, async () => {
+      const response = await postProduct(
+        createSingleProduct(companyId, "SKU_123"),
+      );
+
+      expect(response.status).toBe(201);
+      expect(testContext.findBy).toHaveBeenCalledWith({
+        sku: "SKU_123",
+        companyId: testContext.user.companyId,
+      });
+      expect(testContext.create).toHaveBeenCalledWith(
+        expect.objectContaining({ companyId: testContext.user.companyId }),
+      );
+    });
+  }
+});

--- a/src/product/__TEST__/product-schema.test.ts
+++ b/src/product/__TEST__/product-schema.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "vitest";
+import {
+  PackageProductSchema,
+  ServiceProductSchema,
+  SingleProductSchema,
+} from "@/product/schema";
+import { KG_UNIT_TYPE } from "@/product/types";
+
+describe("product schemas", () => {
+  test("SingleProductSchema rejects empty company identifiers", () => {
+    const product = {
+      companyId: "",
+      name: "Producto simple",
+      price: 10,
+      purchasePrice: 5,
+      description: "Descripción",
+      stock: 1,
+      photos: [],
+      unitType: KG_UNIT_TYPE,
+      categories: [],
+    };
+
+    expect(SingleProductSchema.safeParse(product).success).toBe(false);
+    expect(
+      SingleProductSchema.safeParse({ ...product, companyId: "   " }).success,
+    ).toBe(false);
+  });
+
+  test("PackageProductSchema rejects empty company identifiers", () => {
+    const product = {
+      companyId: "",
+      name: "Paquete de prueba",
+      price: 20,
+      description: "Descripción",
+      photos: [],
+      categories: [],
+      productItems: [],
+    };
+
+    expect(PackageProductSchema.safeParse(product).success).toBe(false);
+    expect(
+      PackageProductSchema.safeParse({ ...product, companyId: "   " }).success,
+    ).toBe(false);
+  });
+
+  test("ServiceProductSchema rejects empty company identifiers", () => {
+    const product = {
+      companyId: "",
+      name: "Servicio de prueba",
+      price: 15,
+      description: "Descripción",
+      photos: [],
+      categories: [],
+    };
+
+    expect(ServiceProductSchema.safeParse(product).success).toBe(false);
+    expect(
+      ServiceProductSchema.safeParse({ ...product, companyId: "   " }).success,
+    ).toBe(false);
+  });
+});

--- a/src/product/components/form/package-product-modal-form.tsx
+++ b/src/product/components/form/package-product-modal-form.tsx
@@ -16,10 +16,7 @@ import React, { useEffect } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { PackageProduct, PackageProductType, Photo } from "@/product/types";
-import {
-  EMPTY_PACKAGE_PRODUCT,
-  EMPTY_SINGLE_PRODUCT,
-} from "@/product/constants";
+import { EMPTY_PACKAGE_PRODUCT } from "@/product/constants";
 import * as repository from "@/product/api_repository";
 import FileUpload from "@/product/components/file-upload/file-upload";
 import {
@@ -45,11 +42,16 @@ import { useProductFormStore } from "@/product/components/form/product-form-stor
 import { ReloadIcon } from "@radix-ui/react-icons";
 import { useUserSession } from "@/lib/use-user-session";
 import ProductItemsSelector from "@/product/components/form/product-items-selector";
-import { useProductsStore } from "@/product/components/products-store-provider";
-import { getCompany } from "@/order/actions";
 import CategoriesModal from "@/category/components/category-list-model/category-modal";
 
 type ProductFormValues = z.infer<typeof PackageProductSchema>;
+
+const getEmptyProductFormValues = (
+  companyId?: string,
+): ProductFormValues => ({
+  ...EMPTY_PACKAGE_PRODUCT,
+  companyId: companyId || "",
+});
 
 const transformToProduct = (
   data: ProductFormValues,
@@ -97,23 +99,24 @@ const PackageProductModalForm: React.FC<ProductFormProps> = ({
   const form = useForm<ProductFormValues>({
     resolver: zodResolver(PackageProductSchema),
     defaultValues: formStore.isNew
-      ? { ...EMPTY_PACKAGE_PRODUCT }
+      ? getEmptyProductFormValues(user?.companyId)
       : productData || EMPTY_PACKAGE_PRODUCT,
   });
 
-  // Setting the companyId to the product
+  const resetForm = () => {
+    form.reset(getEmptyProductFormValues(user?.companyId));
+  };
+
   useEffect(() => {
+    if (!formStore.open) return;
+
     if (formStore.isNew) {
-      getCompany().then((response) => {
-        if (response.success) {
-          form.setValue("companyId", response.data.id);
-        }
-      });
+      resetForm();
     } else {
       form.reset(productData);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [formStore.isNew, formStore.product, user]);
+  }, [formStore.open, formStore.isNew, formStore.product, user?.companyId]);
 
   const onSubmit = async (data: ProductFormValues) => {
     formStore.setOpen(false);
@@ -134,7 +137,6 @@ const PackageProductModalForm: React.FC<ProductFormProps> = ({
           description:
             "Error al actualizar el pack de productos, " + res.message,
         });
-        formStore.resetProduct(PackageProductType);
       }
     } else {
       const res = await repository.create(transformToProduct(data));
@@ -150,9 +152,11 @@ const PackageProductModalForm: React.FC<ProductFormProps> = ({
           description:
             "Error al registrar el pack de productos, " + res.message,
         });
-        formStore.resetProduct(PackageProductType);
       }
     }
+
+    formStore.resetProduct(PackageProductType);
+    resetForm();
   };
 
   const addCategoryToProduct = async (category: Category) => {
@@ -270,7 +274,17 @@ const PackageProductModalForm: React.FC<ProductFormProps> = ({
   };
 
   return (
-    <Dialog open={formStore.open} onOpenChange={formStore.setOpen}>
+    <Dialog
+      open={formStore.open}
+      onOpenChange={(val) => {
+        if (!val) {
+          resetForm();
+          formStore.resetProduct(PackageProductType);
+          return;
+        }
+        formStore.setOpen(true);
+      }}
+    >
       <DialogContent className="w-full h-full sm:max-w-[750px] sm:h-[750px] w-full flex flex-col justify-center items-center p-0">
         <DialogTitle className="sr-only">{title}</DialogTitle>
         <ScrollArea className="p-6 w-full">

--- a/src/product/components/form/single-product-modal-form.tsx
+++ b/src/product/components/form/single-product-modal-form.tsx
@@ -50,7 +50,6 @@ import {useProductFormStore} from "@/product/components/form/product-form-store-
 import {ReloadIcon} from "@radix-ui/react-icons";
 import {debounce} from "@/lib/utils";
 import {useUserSession} from "@/lib/use-user-session";
-import {getCompany} from "@/order/actions";
 import {
   Select,
   SelectContent,
@@ -64,6 +63,13 @@ import {Switch} from "@/shared/components/ui/switch";
 import {HelpTooltip} from "@/shared/components/ui/help-tooltip";
 
 type ProductFormValues = z.infer<typeof SingleProductSchema>;
+
+const getEmptyProductFormValues = (
+  companyId?: string,
+): ProductFormValues => ({
+  ...EMPTY_SINGLE_PRODUCT,
+  companyId: companyId || "",
+});
 
 const transformToProduct = (
   data: ProductFormValues,
@@ -125,9 +131,15 @@ const SingleProductModalForm: React.FC<ProductFormProps> = ({
   const form = useForm<ProductFormValues>({
     resolver: zodResolver(SingleProductSchema),
     defaultValues: formStore.isNew
-      ? {...EMPTY_SINGLE_PRODUCT}
+      ? getEmptyProductFormValues(user?.companyId)
       : productData || EMPTY_SINGLE_PRODUCT,
   });
+
+  const resetForm = () => {
+    form.reset(getEmptyProductFormValues(user?.companyId));
+    setShowTransferProduct(false);
+    setTargetMovementProduct(undefined);
+  };
 
   const productSku = form.watch("sku");
 
@@ -157,12 +169,10 @@ const SingleProductModalForm: React.FC<ProductFormProps> = ({
   }, [productSku]);
 
   useEffect(() => {
+    if (!formStore.open) return;
+
     if (formStore.isNew) {
-      getCompany().then((response) => {
-        if (response.success) {
-          form.setValue("companyId", response.data.id);
-        }
-      });
+      resetForm();
     } else {
       form.reset({
         ...productData,
@@ -182,7 +192,7 @@ const SingleProductModalForm: React.FC<ProductFormProps> = ({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [formStore.isNew, formStore.product, user]);
+  }, [formStore.open, formStore.isNew, formStore.product, user?.companyId]);
 
   const onSubmit = async (data: ProductFormValues) => {
     formStore.setOpen(false);
@@ -203,8 +213,6 @@ const SingleProductModalForm: React.FC<ProductFormProps> = ({
           description: "Error al actualizar el producto, " + res.message,
         });
       }
-      formStore.resetProduct(SingleProductType);
-      form.reset({...EMPTY_SINGLE_PRODUCT});
     } else {
       const res = await repository.create(transformToProduct(data));
       if (res.success) {
@@ -219,9 +227,10 @@ const SingleProductModalForm: React.FC<ProductFormProps> = ({
           description: "Error al registrar el producto, " + res.message,
         });
       }
-      formStore.resetProduct(SingleProductType);
-      form.reset({...EMPTY_SINGLE_PRODUCT});
     }
+
+    formStore.resetProduct(SingleProductType);
+    resetForm();
   };
 
   const addCategoryToProduct = async (category: Category) => {
@@ -362,12 +371,12 @@ const SingleProductModalForm: React.FC<ProductFormProps> = ({
     <Dialog
       open={formStore.open}
       onOpenChange={(val) => {
-        formStore.resetProduct(SingleProductType);
-        form.reset({...EMPTY_SINGLE_PRODUCT});
-        formStore.setOpen(val);
         if (!val) {
-          setShowTransferProduct(false);
+          resetForm();
+          formStore.resetProduct(SingleProductType);
+          return;
         }
+        formStore.setOpen(true);
       }}
     >
       <DialogContent className="w-full h-full sm:max-w-[750px] sm:h-[750px] flex flex-col justify-center items-center p-0">

--- a/src/product/schema.ts
+++ b/src/product/schema.ts
@@ -3,6 +3,11 @@ import { IMG_MAX_LIMIT } from "@/product/constants";
 import { CategorySchema } from "@/category/schema";
 import { KG_UNIT_TYPE, UNIT_UNIT_TYPE } from "@/product/types";
 
+const CompanyIdSchema = z
+  .string()
+  .trim()
+  .min(1, { message: "La empresa es requerida" });
+
 export const PhotoSchema = z.object({
   id: z.string().optional(),
   name: z.string(),
@@ -15,7 +20,7 @@ export const PhotoSchema = z.object({
 
 export const SingleProductSchema = z.object({
   id: z.string().optional(),
-  companyId: z.string(),
+  companyId: CompanyIdSchema,
   name: z.string().min(3, {
     message: "El nombre del producto debe tener al menos 3 caracteres",
   }),
@@ -54,7 +59,7 @@ export const ProductItemSchema = z.object({
 
 export const PackageProductSchema = z.object({
   id: z.string().optional(),
-  companyId: z.string(),
+  companyId: CompanyIdSchema,
   name: z.string().min(3, {
     message: "El nombre del producto debe tener al menos 3 caracteres",
   }),
@@ -80,7 +85,7 @@ export const PackageProductSchema = z.object({
 
 export const ServiceProductSchema = z.object({
   id: z.string().optional(),
-  companyId: z.string(),
+  companyId: CompanyIdSchema,
   name: z.string().min(3, {
     message: "El nombre del servicio debe tener al menos 3 caracteres",
   }),


### PR DESCRIPTION
## Resumen

- Impone `user.companyId` en `POST /api/products` antes de validar el SKU o persistir.
- Reinicia los formularios de producto simple y paquete con la empresa de la sesión en cada apertura, cierre y creación.
- Elimina las consultas redundantes a `getCompany`.
- Rechaza identificadores de empresa vacíos en los esquemas de producto.
- Agrega pruebas Vitest para creaciones consecutivas, aislamiento del tenant y validación de esquemas.

## Causa raíz

Después de la primera creación, el formulario simple se reiniciaba con `companyId: ""`. Al reabrirlo, las dependencias del efecto no cambiaban y el tenant no se restauraba. Además, la ruta de creación confiaba en el `companyId` enviado por el cliente.

## Impacto

Las creaciones consecutivas de productos simples y paquetes conservan el tenant autenticado y ya no pueden enviar un identificador vacío o perteneciente a otra empresa al repositorio.

## Validación

- `npm test`: 55 pruebas pasaron.
- `npm run build:dev`: pasó.
- ESLint focalizado sobre los archivos modificados: pasó.
- `git diff --check`: pasó.
- `npm run lint` global continúa bloqueado por 18 errores preexistentes en archivos no relacionados.
- La validación manual no pudo completarse porque las credenciales del PostgreSQL local configurado fueron rechazadas.